### PR TITLE
PODAAC-5547

### DIFF
--- a/src/jpl/dijit/LayerControl.js
+++ b/src/jpl/dijit/LayerControl.js
@@ -402,7 +402,7 @@ define([
 });
 
 function calculateImageFilename(granuleName, variableName) {
-    var variableNameWithDots = variableName.replaceAll('/', '.');
+    var variableNameWithDots = variableName.replaceAll('/', '.').replaceAll(' ', '_');
     if (variableNameWithDots[0] !== '.') {
         variableNameWithDots = '.' + variableNameWithDots;
     }

--- a/src/jpl/utils/GranuleMetadata.js
+++ b/src/jpl/utils/GranuleMetadata.js
@@ -45,10 +45,34 @@ define([
             var footprint_data_array, pairs, polygonString;
             var polygonArray = []
             for(var i=0; i< footprint_data.length; i++){
+
+                exclusivePolygonString = null;
+                if('ExclusiveZone' in footprint_data[i]){
+                    exclusiveZone = footprint_data[i]['ExclusiveZone'];
+                    exclusiveZoneArray = [];
+
+                    for(var j=0; j<exclusiveZone['Boundaries'].length; j++){
+                        exclusiveZonePoints = footprint_data[i]['ExclusiveZone']['Boundaries'][j]['Points'];
+                        exclusivePairs = this.getPairs(exclusiveZonePoints);
+                        exclusivePolygonString = sprintf("(%s)", exclusivePairs.join(", "));
+                        exclusiveZoneArray.push(exclusivePolygonString);
+                    }
+                }
+
                 footprint_data_array = footprint_data[i]['Boundary']['Points'];
                 pairs = this.getPairs(footprint_data_array);
-                polygonString = sprintf("((%s))", pairs.join(", "));
-                polygonArray.push(polygonString);
+
+                if(exclusivePolygonString != null){
+                    outerPolygon = sprintf("(%s)", pairs.join(", "));
+                    innerHoles = sprintf("%s", exclusiveZoneArray.join(", "));
+                    polygonString = sprintf("(%s,%s)", outerPolygon, innerHoles);
+                    polygonArray.push(polygonString);
+                }
+                else{
+                    polygonString = sprintf("((%s))", pairs.join(", "));
+                    polygonArray.push(polygonString);
+                }
+
             }
             var multiPolygonString = sprintf("MULTIPOLYGON (%s)", polygonArray.join(", "));
             return multiPolygonString;


### PR DESCRIPTION
- Replace spaces " " in group names to use "_", when we use tig we will be using an _ in the tig to generate png names with spaces in the group names, this is cause it seems the tea app had trouble serving files with spaces in it
- Added a way to generate polygon with holes in them for footprints. 