### PR TITLE
Feature/podaac 5326: fix "add matching granules to download"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add in commit message triggers
+- PODAAC-5326: Fixed 'Add matching granules to download' button.
 ### Changed
 ### Removed
 ### Fixed

--- a/src/hitideConfig.js
+++ b/src/hitideConfig.js
@@ -1,32 +1,48 @@
-var hitideProfileOrigin = "https://hitide.profile.podaac.sit.earthdatacloud.nasa.gov/hitide/api";
+var hitideProfileBase = "https://localhost:8443";
+var edlBase = "https://uat.urs.earthdata.nasa.gov";
+var edlClientId = "dxpH2WeN_f8IpNLgHwplsg";
+var l2ssBase = "https://podaac-tools.jpl.nasa.gov";
+// var cmrBase = "https://localhost:8443/hitide/api/cmr";
+var cmrBase = "https://cmr.uat.earthdata.nasa.gov";
+var gtmId = "--";
 
 window.hitideConfig = {
-    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
-    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
-    paletteService: "https://hitide.podaac.sit.earthdatacloud.nasa.gov/palettes",
+    datasetSearchService: l2ssBase + "/l2ss-services/l2ss/dataset/search",
+    datasetMetadataService: l2ssBase + "/l2ss-services/l2ss/dataset/search",
+    granuleSearchService: l2ssBase + "/l2ss-services/l2ss/granule/search",
+    granuleAvailabilityService: l2ssBase + "/l2ss-services/l2ss/granule/availability",
+    variableService: l2ssBase + "/l2ss-services/l2ss/dataset/variable",
 
-    cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
-    cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",
-    cmrGranuleAvailabilityService: hitideProfileOrigin + "/cmr",
-    cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
-    crossOriginCmrCookies: true,
+    cmrDatasetSearchService: cmrBase + "/search/collections.json?tool_name=HiTIDE",
+    cmrGranuleSearchService: cmrBase + "/search/granules.umm_json",
+    cmrGranuleAvailabilityService: cmrBase,
+    cmrVariableService: calculateCmrGraphqlUrl(cmrBase, hitideProfileBase),
+    crossOriginCmrCookies: cmrBase.includes(hitideProfileBase),
 
-    authCodeUrl: "https://uat.urs.earthdata.nasa.gov/oauth/authorize",
+    authCodeUrl: edlBase + "/oauth/authorize",
 
-    loginUrl: hitideProfileOrigin + "/session/login",
-    logoutUrl: hitideProfileOrigin + "/session/logout",
-    getUserUrl: hitideProfileOrigin + "/session/user/",
-    submitJobUrl: hitideProfileOrigin + "/jobs/submit",
-    jobStatusUrl: hitideProfileOrigin + "/jobs/status",
-    jobHistoryUrl: hitideProfileOrigin + "/jobs/history",
-    disableJobUrl: hitideProfileOrigin + "/jobs/disable",
+    loginUrl: hitideProfileBase + "/hitide/api/session/login",
+    logoutUrl: hitideProfileBase + "/hitide/api/session/logout",
+    getUserUrl: hitideProfileBase + "/hitide/api/session/user/",
+    submitJobUrl: hitideProfileBase + "/hitide/api/jobs/submit",
+    jobStatusUrl: hitideProfileBase + "/hitide/api/jobs/status",
+    jobHistoryUrl: hitideProfileBase + "/hitide/api/jobs/history",
+    disableJobUrl: hitideProfileBase + "/hitide/api/jobs/disable",
     crossOriginCookies: true,
 
+    paletteService: "palettes",
     datasetSearchServiceItemsPerPage: 200,
     maxGranulesPerDownload: 999999999,
-    googleTagManagerId: "GTM-M5D83V6",
-    earthDataAppClientId: "dxpH2WeN_f8IpNLgHwplsg"
+    googleTagManagerId: gtmId,
+    earthDataAppClientId: edlClientId,
+    showCloudMigrationDialog: false
 };
+
+function calculateCmrGraphqlUrl(cmrBase, hitideProfileBase) {
+    return (
+        cmrBase.includes(hitideProfileBase) ? cmrBase + "/graphql" :
+        cmrBase.includes("uat") ? "https://graphql.uat.earthdata.nasa.gov/api" :
+        cmrBase.includes("sit") ? "https://graphql.sit.earthdata.nasa.gov/api" :
+        "https://graphql.earthdata.nasa.gov/api"
+    );
+}

--- a/src/hitideConfig.js
+++ b/src/hitideConfig.js
@@ -1,49 +1,32 @@
-var hitideProfileBase = "https://localhost:8443";
-var edlBase = "https://uat.urs.earthdata.nasa.gov";
-var edlClientId = "dxpH2WeN_f8IpNLgHwplsg";
-var l2ssBase = "https://podaac-tools.jpl.nasa.gov";
-// var cmrBase = "https://localhost:8443/hitide/api/cmr";
-var cmrBase = "https://cmr.uat.earthdata.nasa.gov";
-var gtmId = "--";
+var hitideProfileOrigin = "https://hitide.profile.podaac.sit.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    datasetSearchService: l2ssBase + "/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: l2ssBase + "/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: l2ssBase + "/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: l2ssBase + "/l2ss-services/l2ss/granule/availability",
-    variableService: l2ssBase + "/l2ss-services/l2ss/dataset/variable",
+    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
+    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
+    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
+    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
+    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
+    paletteService: "https://hitide.podaac.sit.earthdatacloud.nasa.gov/palettes",
 
-    cmrDatasetSearchService: cmrBase + "/search/collections.json?tool_name=HiTIDE",
-    cmrGranuleSearchService: cmrBase + "/search/granules.umm_json",
-    cmrGranuleAvailabilityService: cmrBase,
-    cmrVariableService: calculateCmrGraphqlUrl(cmrBase, hitideProfileBase),
-    crossOriginCmrCookies: cmrBase.includes(hitideProfileBase),
+    cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
+    cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",
+    cmrGranuleAvailabilityService: hitideProfileOrigin + "/cmr",
+    cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
+    crossOriginCmrCookies: true,
 
-    authCodeUrl: edlBase + "/oauth/authorize",
+    authCodeUrl: "https://uat.urs.earthdata.nasa.gov/oauth/authorize",
 
-    loginUrl: hitideProfileBase + "/hitide/api/session/login",
-    logoutUrl: hitideProfileBase + "/hitide/api/session/logout",
-    getUserUrl: hitideProfileBase + "/hitide/api/session/user/",
-    submitJobUrl: hitideProfileBase + "/hitide/api/jobs/submit",
-    jobStatusUrl: hitideProfileBase + "/hitide/api/jobs/status",
-    jobHistoryUrl: hitideProfileBase + "/hitide/api/jobs/history",
-    disableJobUrl: hitideProfileBase + "/hitide/api/jobs/disable",
+    loginUrl: hitideProfileOrigin + "/session/login",
+    logoutUrl: hitideProfileOrigin + "/session/logout",
+    getUserUrl: hitideProfileOrigin + "/session/user/",
+    submitJobUrl: hitideProfileOrigin + "/jobs/submit",
+    jobStatusUrl: hitideProfileOrigin + "/jobs/status",
+    jobHistoryUrl: hitideProfileOrigin + "/jobs/history",
+    disableJobUrl: hitideProfileOrigin + "/jobs/disable",
     crossOriginCookies: true,
 
-    paletteService: "palettes",
     datasetSearchServiceItemsPerPage: 200,
     maxGranulesPerDownload: 999999999,
-    googleTagManagerId: gtmId,
-    earthDataAppClientId: edlClientId,
-    showCloudMigrationDialog: false
+    googleTagManagerId: "GTM-M5D83V6",
+    earthDataAppClientId: "dxpH2WeN_f8IpNLgHwplsg"
 };
-
-function calculateCmrGraphqlUrl(cmrBase, hitideProfileBase) {
-    return (
-        cmrBase.includes(hitideProfileBase) ? cmrBase + "/graphql" :
-        cmrBase.includes("uat") ? "https://graphql.uat.earthdata.nasa.gov/api" :
-        cmrBase.includes("sit") ? "https://graphql.sit.earthdata.nasa.gov/api" :
-        "https://graphql.earthdata.nasa.gov/api"
-    );
-}
-

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -630,9 +630,7 @@ define([
         fetchGranulesNames: function() {
             // Set searching flag to true
             this._granuleSearchInProgress = true;
-            // Show spinner 
-            this.displayLoadingSpinner(true);
-
+        
             var withCredentials = false;
 
             var url;

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -1143,6 +1143,7 @@ define([
             } else {
                 // 
                 var _context = this
+                // get the granule names and add download query
                 _context.fetchGranulesNames()
             }
         },

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -1043,9 +1043,6 @@ define([
                     return granuleRow.getElementsByClassName('field-Granule-Name')[0].innerHTML
                 })
 
-                // eslint-disable-next-line no-console
-                console.log(granuleNameIds)
-
                 var startDate = moment.utc(this.startDateWidget.getValue());
                 var endDate = moment.utc(this.endDateWidget.getValue());
                 var queryId = Math.floor(Math.random() * (9999999999 - 0)) + 0;
@@ -1062,8 +1059,6 @@ define([
                     granuleNamesFilter: this.nameFilterBox.value,
                     queryId: queryId
                 };
-                // eslint-disable-next-line no-console
-                console.log(downloadQuery)
                 /* add source: 'cmr' if appropriate */
                 if(this.source === 'cmr')
                     downloadQuery.source = 'cmr';

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -125,8 +125,8 @@ define([
                 };
                 topic.publish(GranuleSelectionEvent.prototype.VARIABLES_FETCHED, message);
             });
-
-            // set up button listener
+            
+            // // set up button listener
             on(this.addMatchingBtn, "click", lang.hitch(this, this.handleDownloadMatching));
             on(this.matchingAddedMessageUndo, "click", lang.hitch(this, this.removeMatchingDownload));
 
@@ -1037,6 +1037,15 @@ define([
                         "matching granules is less than the specified limit."
                 }).startup();
             } else {
+                // 
+                var _context = this
+                var granuleNameIds = _context.granuleGrid.observers[0].rows.map(function(granuleRow){
+                    return granuleRow.getElementsByClassName('field-Granule-Name')[0].innerHTML
+                })
+
+                // eslint-disable-next-line no-console
+                console.log(granuleNameIds)
+
                 var startDate = moment.utc(this.startDateWidget.getValue());
                 var endDate = moment.utc(this.endDateWidget.getValue());
                 var queryId = Math.floor(Math.random() * (9999999999 - 0)) + 0;
@@ -1049,10 +1058,12 @@ define([
                     bbox: this.bbox.toString(),
                     notifyOnRemove: true,
                     variables: this.datasetVariables,
-                    granuleNames: [],
+                    granuleNames: granuleNameIds,
                     granuleNamesFilter: this.nameFilterBox.value,
                     queryId: queryId
                 };
+                // eslint-disable-next-line no-console
+                console.log(downloadQuery)
                 /* add source: 'cmr' if appropriate */
                 if(this.source === 'cmr')
                     downloadQuery.source = 'cmr';

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -652,6 +652,7 @@ define([
                 url = this.config.hitide.externalConfigurables.cmrGranuleSearchService + "?";
                 url += "collection_concept_id=" + this.datasetId;
                 url += "&bounding_box[]=" + (this.bbox || "");
+                // limit is ~2000 for page size
                 url += "&page_size=" + this.availableGranules;
                 url += "&offset=" + this.currentSolrIdx;
                 url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
@@ -694,9 +695,16 @@ define([
                 topicHandler.remove();
                 // Update accordingly
                 if (_context.domNode) {
-                    var granuleNamesToReturn = response.response.docs.map(function(granuleObj) {
-                        return granuleObj['Granule-Name']
-                    })
+                    var granuleNamesToReturn
+                    if (_context.source === 'cmr') {
+                        granuleNamesToReturn = response.items.map(function(granuleObj) {
+                            return granuleObj["meta"]["native-id"];
+                        });
+                    } else {
+                        granuleNamesToReturn = response.response.docs.map(function(granuleObj) {
+                            return granuleObj['Granule-Name']
+                        })
+                    }
                     var startDate = moment.utc(_context.startDateWidget.getValue());
                     var endDate = moment.utc(_context.endDateWidget.getValue());
                     var queryId = Math.floor(Math.random() * (9999999999 - 0)) + 0;

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -73,6 +73,7 @@ define([
         itemsPerPage: 25,
         currentSolrIdx: 0,
         availableGranules: 0,
+        granuleNames: [],
         granulesInGrid: 0,
         _granuleSearchInProgress: false,
         loadingGranulesMessage: '<div class="granulesControllerLoadingGranulesMessage">Loading Granules...</div>',
@@ -620,17 +621,126 @@ define([
             this._eventListeners.push(topic.subscribe(DownloadsEvent.prototype.JOB_SUBMITTED, lang.hitch(this, this.resetHandleDownloadMatchingBtn)))
             this._eventListeners.push(topic.subscribe(MyDataEvent.prototype.REMOVE_DOWNLOAD_QUERY_NOTIFY, lang.hitch(this, this.handleRemoveDownloadQueryNotify)))
             this._eventListeners.push(topic.subscribe(MapEvent.prototype.MAP_INITIALIZED, lang.hitch(this, this.mapInitialized)));
-
         },
 
         displayLoadingSpinner: function(display) {
             domStyle.set(this.granulesControllerLoadingSpinner, "visibility", (display ? "visible" : "hidden"));
         },
 
+        fetchGranulesNames: function() {
+            // Set searching flag to true
+            this._granuleSearchInProgress = true;
+            // Show spinner 
+            this.displayLoadingSpinner(true);
+
+            var withCredentials = false;
+
+            var url;
+            if(this.source === "cmr"){
+
+                var sort 
+                if(this.granuleGrid._sort[0].attribute == "Granule-StartTime"){
+                    sort = "start_date";
+                }
+                else if(this.granuleGrid._sort[0].attribute == "Granule-StopTime"){
+                    sort = "end_date";
+                }
+                else if(this.granuleGrid._sort[0].attribute ==  "Granule-Name"){
+                    sort = "readable_granule_name";
+                }
+
+                url = this.config.hitide.externalConfigurables.cmrGranuleSearchService + "?";
+                url += "collection_concept_id=" + this.datasetId;
+                url += "&bounding_box[]=" + (this.bbox || "");
+                url += "&page_size=" + this.availableGranules;
+                url += "&offset=" + this.currentSolrIdx;
+                url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
+                url += "&sort_key[]=" + (this.granuleGrid._sort[0].descending ? "-" : "%2B") + sort
+                
+                if(this.nameFilterBox.get("value")){
+                    url += "&native_id[]=" + this.nameFilterBox.get("value") + "&options[native_id][pattern]=true";
+                }
+
+                withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
+            }
+            else{
+                url = this.config.hitide.externalConfigurables.granuleSearchService + "?";
+                url += "datasetId=" + this.datasetId;
+                url += "&startTime=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value"));
+                url += "&endTime=" + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
+                url += "&name=" + this.nameFilterBox.get("value");
+                url += "&bbox=" + (this.bbox || "");
+                url += "&itemsPerPage=" + this.availableGranules;
+                url += "&startIndex=" + this.currentSolrIdx;
+                url += "&sort=" + this.granuleGrid._sort[0].attribute + (this.granuleGrid._sort[0].descending ? " desc" : " asc");
+            }
+
+            var _context = this;
+            var r;
+            var topicHandler = topic.subscribe(SearchEvent.prototype.CANCEL_REQUESTS, function(message) {
+                if (message.target === "*" || message.target === this.datasetId) {
+                    r.cancel();
+                }
+            });
+            r = xhr.get(url, {
+                headers: {
+                    "X-Requested-With": null
+                },
+                handleAs: "json",
+                method: "get",
+                withCredentials: withCredentials
+            }).then(function(response) {
+                // Unsubscribe from cancel requests
+                topicHandler.remove();
+                // Update accordingly
+                if (_context.domNode) {
+                    var granuleNamesToReturn = response.response.docs.map(function(granuleObj) {
+                        return granuleObj['Granule-Name']
+                    })
+                    var startDate = moment.utc(_context.startDateWidget.getValue());
+                    var endDate = moment.utc(_context.endDateWidget.getValue());
+                    var queryId = Math.floor(Math.random() * (9999999999 - 0)) + 0;
+                    var downloadQuery = {
+                        datasetId: _context.datasetId,
+                        datasetShortName: _context.datasetShortName,
+                        startDate: startDate.format("YYYY/MM/DD"),
+                        endDate: endDate.format("YYYY/MM/DD"),
+                        numSelected: _context.availableGranules,
+                        bbox: _context.bbox.toString(),
+                        notifyOnRemove: true,
+                        variables: _context.datasetVariables,
+                        granuleNames: granuleNamesToReturn,
+                        granuleNamesFilter: _context.nameFilterBox.value,
+                        queryId: queryId
+                    };
+                    /* add source: 'cmr' if appropriate */
+                    if(_context.source === 'cmr')
+                        downloadQuery.source = 'cmr';
+                    topic.publish(MyDataEvent.prototype.ADD_DOWNLOAD_QUERY, downloadQuery);
+                    _context.queryId = queryId;
+                    domStyle.set(_context.addMatchingBtn, "display", "none");
+                    domStyle.set(_context.matchingAddedMessage, "display", "block");
+                }
+            }, function(err) {
+                // Unsubscribe from cancel requests
+                topicHandler.remove();
+                console.log("ERROR", err);
+                // Set searching flag to false
+                _context._granuleSearchInProgress = false;
+
+                // Show spinner 
+                _context.displayLoadingSpinner(false);
+
+                // new AlertDialog({
+                //     alertTitle: "Server Error",
+                //     alertMessage: "Unable to fetch dataset variables for <b>" + this.datasetShortName + "</b>. Please try again later."
+                // }).startup();
+            });
+        },
+
         fetchGranules: function() {
             // Set searching flag to true
             this._granuleSearchInProgress = true;
-
             // Show spinner 
             this.displayLoadingSpinner(true);
 
@@ -658,7 +768,6 @@ define([
                 url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
                 url += "&sort_key[]=" + (this.granuleGrid._sort[0].descending ? "-" : "%2B") + sort
                 
-                console.log(url);
                 if(this.nameFilterBox.get("value")){
                     url += "&native_id[]=" + this.nameFilterBox.get("value") + "&options[native_id][pattern]=true";
                 }
@@ -719,16 +828,13 @@ define([
                 // }).startup();
             });
         },
-
         
         postGranulesFetch: function(response) {
             if(this.source === "cmr"){
                 this.availableGranules = response.hits;
                 var _context = this;
                 response.items.map(function(x) {
-
                     GranuleMetadata.convertFootprintAndImageFromCMR(x);
-
                     var granule_id = x["meta"]["concept-id"];
                     var fpState = _context.stateStore.get(granule_id);
                     var previewState = _context.stateStore.get(granule_id);
@@ -751,11 +857,9 @@ define([
                 this.availableGranules = response.response.numFound;
                 var _context = this;
                 response.response.docs.map(function(x) {
-
                     // MapUtil and Terraformer don't properly handle granule footprints or extents
                     // when they are ENVELOPE type. So, convert all ENVELOPE strings to POLYGON strings.
                     GranuleMetadata.convertFootprintsAndExtentsFromEnvelopeToPolygon(x);
-
                     // Add extra fields to response docs
                     // Check for state in stateStore
                     var fpState = _context.stateStore.get(x["Granule-Id"]);
@@ -1039,34 +1143,7 @@ define([
             } else {
                 // 
                 var _context = this
-                var granuleNameIds = _context.granuleGrid.observers[0].rows.map(function(granuleRow){
-                    return granuleRow.getElementsByClassName('field-Granule-Name')[0].innerHTML
-                })
-
-                var startDate = moment.utc(this.startDateWidget.getValue());
-                var endDate = moment.utc(this.endDateWidget.getValue());
-                var queryId = Math.floor(Math.random() * (9999999999 - 0)) + 0;
-                var downloadQuery = {
-                    datasetId: this.datasetId,
-                    datasetShortName: this.datasetShortName,
-                    startDate: startDate.format("YYYY/MM/DD"),
-                    endDate: endDate.format("YYYY/MM/DD"),
-                    numSelected: this.availableGranules,
-                    bbox: this.bbox.toString(),
-                    notifyOnRemove: true,
-                    variables: this.datasetVariables,
-                    granuleNames: granuleNameIds,
-                    granuleNamesFilter: this.nameFilterBox.value,
-                    queryId: queryId
-                };
-                /* add source: 'cmr' if appropriate */
-                if(this.source === 'cmr')
-                    downloadQuery.source = 'cmr';
-
-                topic.publish(MyDataEvent.prototype.ADD_DOWNLOAD_QUERY, downloadQuery);
-                this.queryId = queryId;
-                domStyle.set(this.addMatchingBtn, "display", "none");
-                domStyle.set(this.matchingAddedMessage, "display", "block");
+                _context.fetchGranulesNames()
             }
         },
 
@@ -1101,7 +1178,6 @@ define([
                     latestTime = stopTime;
                 }
             });
-
 
             // Alert user if > max granule downloads and block
             if (granuleNameIds.length > this.config.hitide.externalConfigurables.maxGranulesPerDownload) {

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -736,11 +736,6 @@ define([
 
                 // Show spinner 
                 _context.displayLoadingSpinner(false);
-
-                // new AlertDialog({
-                //     alertTitle: "Server Error",
-                //     alertMessage: "Unable to fetch dataset variables for <b>" + this.datasetShortName + "</b>. Please try again later."
-                // }).startup();
             });
         },
 


### PR DESCRIPTION
Changes:
- Added function to fetch all granules and get their granules names when clicking on "add matching to download"
- Added granule names to be sent to harmony call

Tested:
- tested and working locally and in SIT