### PR TITLE
Hitide UI 15: remove on-premise references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- issue-15: getting cloud resolution metedata using normal get instead of graphql because it is faster
+- issue-15: changed FAQ references to cloud icon and cut scanline
 ### Removed
+- issue-15: removed references to l2ss
+- issue-15: removed cloud icons from datasets
+- issue-15: removed cut scanline option in download options tab
 ### Fixed
-
+- issue-15: fixed color palette error in legend when selecting datasets
 
 ## [4.15.0]
 ### Added

--- a/configs/hitideConfig-ops.js
+++ b/configs/hitideConfig-ops.js
@@ -2,6 +2,7 @@ var hitideProfileOrigin = "https://hitide.profile.podaac.earthdatacloud.nasa.gov
 
 window.hitideConfig = {
     paletteService: "https://hitide.podaac.earthdatacloud.nasa.gov/palettes",
+    // paletteService: hitideProfileOrigin + "/palettes",
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
     cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",

--- a/configs/hitideConfig-ops.js
+++ b/configs/hitideConfig-ops.js
@@ -6,6 +6,7 @@ window.hitideConfig = {
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
     cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",
+    cmrCollectionSearchService: hitideProfileOrigin + "/cmr/search/concepts",
     cmrGranuleAvailabilityService: hitideProfileOrigin + "/cmr",
     cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
     crossOriginCmrCookies: true,

--- a/configs/hitideConfig-ops.js
+++ b/configs/hitideConfig-ops.js
@@ -1,11 +1,6 @@
 var hitideProfileOrigin = "https://hitide.profile.podaac.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
-    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
     paletteService: "https://hitide.podaac.earthdatacloud.nasa.gov/palettes",
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",

--- a/configs/hitideConfig-sit.js
+++ b/configs/hitideConfig-sit.js
@@ -5,6 +5,7 @@ window.hitideConfig = {
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
     cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",
+    cmrCollectionSearchService: hitideProfileOrigin + "/cmr/search/concepts",
     cmrGranuleAvailabilityService: hitideProfileOrigin + "/cmr",
     cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
     crossOriginCmrCookies: true,

--- a/configs/hitideConfig-sit.js
+++ b/configs/hitideConfig-sit.js
@@ -1,11 +1,6 @@
 var hitideProfileOrigin = "https://hitide.profile.podaac.sit.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
-    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
     paletteService: "https://hitide.podaac.sit.earthdatacloud.nasa.gov/palettes",
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",

--- a/configs/hitideConfig-uat.js
+++ b/configs/hitideConfig-uat.js
@@ -1,11 +1,7 @@
 var hitideProfileOrigin = "https://hitide.profile.podaac.uat.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
-    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
+    // variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
     paletteService: "https://hitide.podaac.uat.earthdatacloud.nasa.gov/palettes",
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",

--- a/configs/hitideConfig-uat.js
+++ b/configs/hitideConfig-uat.js
@@ -5,6 +5,7 @@ window.hitideConfig = {
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
     cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",
+    cmrCollectionSearchService: hitideProfileOrigin + "/cmr/search/concepts",
     cmrGranuleAvailabilityService: hitideProfileOrigin + "/cmr",
     cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
     crossOriginCmrCookies: true,

--- a/configs/hitideConfig-uat.js
+++ b/configs/hitideConfig-uat.js
@@ -1,7 +1,6 @@
 var hitideProfileOrigin = "https://hitide.profile.podaac.uat.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    // variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
     paletteService: "https://hitide.podaac.uat.earthdatacloud.nasa.gov/palettes",
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.15.0",
+  "version": "4.16.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-0",
+  "version": "4.16.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-0",
+  "version": "4.16.0-1",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.15.0",
+  "version": "4.16.0-0",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/src/hitideConfig.js
+++ b/src/hitideConfig.js
@@ -1,48 +1,33 @@
-var hitideProfileBase = "https://localhost:8443";
-var edlBase = "https://uat.urs.earthdata.nasa.gov";
-var edlClientId = "dxpH2WeN_f8IpNLgHwplsg";
-var l2ssBase = "https://podaac-tools.jpl.nasa.gov";
-// var cmrBase = "https://localhost:8443/hitide/api/cmr";
-var cmrBase = "https://cmr.uat.earthdata.nasa.gov";
-var gtmId = "--";
+var hitideProfileOrigin = "https://hitide.profile.podaac.uat.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    datasetSearchService: l2ssBase + "/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: l2ssBase + "/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: l2ssBase + "/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: l2ssBase + "/l2ss-services/l2ss/granule/availability",
-    variableService: l2ssBase + "/l2ss-services/l2ss/dataset/variable",
+    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
+    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
+    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
+    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
+    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
+    paletteService: "https://hitide.podaac.uat.earthdatacloud.nasa.gov/palettes",
 
-    cmrDatasetSearchService: cmrBase + "/search/collections.json?tool_name=HiTIDE",
-    cmrGranuleSearchService: cmrBase + "/search/granules.umm_json",
-    cmrGranuleAvailabilityService: cmrBase,
-    cmrVariableService: calculateCmrGraphqlUrl(cmrBase, hitideProfileBase),
-    crossOriginCmrCookies: cmrBase.includes(hitideProfileBase),
+    cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",
+    cmrGranuleSearchService: hitideProfileOrigin + "/cmr/search/granules.umm_json",
+    cmrCollectionSearchService: hitideProfileOrigin + "/cmr/search/concepts",
+    cmrGranuleAvailabilityService: hitideProfileOrigin + "/cmr",
+    cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
+    crossOriginCmrCookies: true,
 
-    authCodeUrl: edlBase + "/oauth/authorize",
+    authCodeUrl: "https://uat.urs.earthdata.nasa.gov/oauth/authorize",
 
-    loginUrl: hitideProfileBase + "/hitide/api/session/login",
-    logoutUrl: hitideProfileBase + "/hitide/api/session/logout",
-    getUserUrl: hitideProfileBase + "/hitide/api/session/user/",
-    submitJobUrl: hitideProfileBase + "/hitide/api/jobs/submit",
-    jobStatusUrl: hitideProfileBase + "/hitide/api/jobs/status",
-    jobHistoryUrl: hitideProfileBase + "/hitide/api/jobs/history",
-    disableJobUrl: hitideProfileBase + "/hitide/api/jobs/disable",
+    loginUrl: hitideProfileOrigin + "/session/login",
+    logoutUrl: hitideProfileOrigin + "/session/logout",
+    getUserUrl: hitideProfileOrigin + "/session/user/",
+    submitJobUrl: hitideProfileOrigin + "/jobs/submit",
+    jobStatusUrl: hitideProfileOrigin + "/jobs/status",
+    jobHistoryUrl: hitideProfileOrigin + "/jobs/history",
+    disableJobUrl: hitideProfileOrigin + "/jobs/disable",
     crossOriginCookies: true,
 
-    paletteService: "palettes",
     datasetSearchServiceItemsPerPage: 200,
     maxGranulesPerDownload: 999999999,
-    googleTagManagerId: gtmId,
-    earthDataAppClientId: edlClientId,
-    showCloudMigrationDialog: false
+    googleTagManagerId: "GTM-M5D83V6",
+    earthDataAppClientId: "dxpH2WeN_f8IpNLgHwplsg"
 };
-
-function calculateCmrGraphqlUrl(cmrBase, hitideProfileBase) {
-    return (
-        cmrBase.includes(hitideProfileBase) ? cmrBase + "/graphql" :
-        cmrBase.includes("uat") ? "https://graphql.uat.earthdata.nasa.gov/api" :
-        cmrBase.includes("sit") ? "https://graphql.sit.earthdata.nasa.gov/api" :
-        "https://graphql.earthdata.nasa.gov/api"
-    );
-}

--- a/src/hitideConfig.js
+++ b/src/hitideConfig.js
@@ -1,11 +1,6 @@
 var hitideProfileOrigin = "https://hitide.profile.podaac.uat.earthdatacloud.nasa.gov/hitide/api";
 
 window.hitideConfig = {
-    datasetSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    datasetMetadataService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/search",
-    granuleSearchService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/search",
-    granuleAvailabilityService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/granule/availability",
-    variableService: "https://podaac-tools.jpl.nasa.gov/l2ss-services/l2ss/dataset/variable",
     paletteService: "https://hitide.podaac.uat.earthdatacloud.nasa.gov/palettes",
 
     cmrDatasetSearchService: hitideProfileOrigin + "/cmr/search/collections.json?tool_name=HiTIDE",

--- a/src/hitideConfig.js.cm
+++ b/src/hitideConfig.js.cm
@@ -3,14 +3,8 @@
 var hitideProfileOrigin = "$PROFILE_API";
 
 window.hitideConfig = {
-    
-    datasetSearchService: "$MIDDLEWARE_SERVICE/l2ss/dataset/search",
-    datasetMetadataService: "$MIDDLEWARE_SERVICE/l2ss/dataset/search",
-
-    granuleSearchService: "$MIDDLEWARE_SERVICE/l2ss/granule/search",
-    granuleAvailabilityService: "$MIDDLEWARE_SERVICE/l2ss/granule/availability",
-    variableService: "$MIDDLEWARE_SERVICE/l2ss/dataset/variable",
     paletteService: "$MIDDLEWARE_SERVICE/l2ss/palettes",
+
 
     authCodeUrl: "https://urs.earthdata.nasa.gov/oauth/authorize",
     loginUrl: hitideProfileOrigin + "/hitide/api/session/login",

--- a/src/jpl/dijit/DatasetAvailability.js
+++ b/src/jpl/dijit/DatasetAvailability.js
@@ -23,12 +23,10 @@ define([
     "jpl/config/Config",
     "jpl/utils/DOMUtil",
     "jpl/dijit/ui/AlertDialog",
-    "jpl/utils/GranuleAvailability/L2ssAvailabilityApi",
     "jpl/utils/GranuleAvailability/CmrAvailabilityApi",
     "jpl/utils/GranuleAvailability/CombinedAvailabilityApi"
 ], function(declare, lang, on, domConstruct, domClass, domAttr, domStyle, topic, query, mouse, Deferred, all, xhr, coreFx, registry,
-    _WidgetBase, _TemplatedMixin, DateTextBox, template, css, highcharts, Config, DOMUtil, AlertDialog, 
-    L2ssAvailabilityApi, CmrAvailabilityApi, CombinedAvailabilityApi) {
+    _WidgetBase, _TemplatedMixin, DateTextBox, template, css, highcharts, Config, DOMUtil, AlertDialog, CmrAvailabilityApi, CombinedAvailabilityApi) {
     return declare([_WidgetBase, _TemplatedMixin], {
         templateString: template,
         widgetsInTemplate: true,

--- a/src/jpl/dijit/DatasetAvailability.js
+++ b/src/jpl/dijit/DatasetAvailability.js
@@ -79,10 +79,8 @@ define([
         },
 
         initializeAvailabilityApi: function() {
-            var l2ssAvailabilityApi = new L2ssAvailabilityApi(this.config.hitide.externalConfigurables.granuleAvailabilityService);
             var cmrAvailabilityApi = new CmrAvailabilityApi(this.config.hitide.externalConfigurables.cmrGranuleAvailabilityService);
             this.availability = new CombinedAvailabilityApi({
-                l2ssAvailabilityApi: l2ssAvailabilityApi,
                 cmrAvailabilityApi: cmrAvailabilityApi
             });
         },

--- a/src/jpl/dijit/Downloads.js
+++ b/src/jpl/dijit/Downloads.js
@@ -78,11 +78,11 @@ define([
                 this.submitDownloadQueries();
             }));
 
-            // Check that the visibility of cutScanlineWarning is correctly set. Update whenever a new download query is added/removed.
-            this.updateCutScanlineWarningVisibility();
-            topic.subscribe(MyDataEvent.prototype.ADD_DOWNLOAD_QUERY, lang.hitch(this, this.updateCutScanlineWarningVisibility));
-            topic.subscribe(MyDataEvent.prototype.REMOVE_DOWNLOAD_QUERY, lang.hitch(this, this.updateCutScanlineWarningVisibility));
-            topic.subscribe(DownloadsEvent.prototype.JOB_SUBMITTED, lang.hitch(this, this.updateCutScanlineWarningVisibility));
+            // // Check that the visibility of cutScanlineWarning is correctly set. Update whenever a new download query is added/removed.
+            // this.updateCutScanlineWarningVisibility();
+            // topic.subscribe(MyDataEvent.prototype.ADD_DOWNLOAD_QUERY, lang.hitch(this, this.updateCutScanlineWarningVisibility));
+            // topic.subscribe(MyDataEvent.prototype.REMOVE_DOWNLOAD_QUERY, lang.hitch(this, this.updateCutScanlineWarningVisibility));
+            // topic.subscribe(DownloadsEvent.prototype.JOB_SUBMITTED, lang.hitch(this, this.updateCutScanlineWarningVisibility));
         },
 
         handleLoginStatusChange: function(loginStatus){
@@ -184,14 +184,14 @@ define([
             }).startup();
         },
 
-        updateCutScanlineWarningVisibility: function () {
-            if(this.cloudDatasetQueryExists()) {
-                domClass.remove(this.cutAtScanlineCloudWarning, "hidden");
-            }
-            else {
-                domClass.add(this.cutAtScanlineCloudWarning, "hidden");
-            }
-        },
+        // updateCutScanlineWarningVisibility: function () {
+        //     if(this.cloudDatasetQueryExists()) {
+        //         domClass.remove(this.cutAtScanlineCloudWarning, "hidden");
+        //     }
+        //     else {
+        //         domClass.add(this.cutAtScanlineCloudWarning, "hidden");
+        //     }
+        // },
 
         cloudDatasetQueryExists: function() {
             var downloadQueryArray = Object.values(DownloadQueriesTracker.getCurrentQueries());

--- a/src/jpl/dijit/Downloads.js
+++ b/src/jpl/dijit/Downloads.js
@@ -121,13 +121,6 @@ define([
                     mergeGranules: this.mergeGranulesSelection.checked
                 };
                 
-                // Submit one job for ALL l2ss subjobs...
-                // And one job for EACH cloud subjob
-                var l2ssJob = {
-                    email: this.downloadsSubmissionEmail.value,
-                    subjobs: []
-                }
-                
                 for (var subjobId in subjobs) {
                     if (subjobs.hasOwnProperty(subjobId)) {
                         var subjob = subjobs[subjobId];
@@ -140,14 +133,8 @@ define([
                             cloudJob.subjobs.push(subjob.getFullDownloadQuery(downloadOptions));
                             this.downloadsManager.submitJob(cloudJob);
                         }
-                        else{
-                            l2ssJob.subjobs.push(subjob.getFullDownloadQuery(downloadOptions));
-                        }
                     }
                 }
-
-                if(l2ssJob.subjobs.length > 0)
-                    this.downloadsManager.submitJob(l2ssJob);
             }
         },
 

--- a/src/jpl/dijit/GranuleSelection.js
+++ b/src/jpl/dijit/GranuleSelection.js
@@ -276,14 +276,6 @@ define([
                 url += "&page_size=0"
                 withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
             }
-            else{
-                url = this.config.hitide.externalConfigurables.granuleSearchService + "?";
-                url += "datasetId=" + datasetId;
-                url += "&startTime=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(startTime);
-                url += "&endTime=" + DOMUtil.prototype.dateFormatISOEndOfDay(endTime);
-                url += "&bbox=" + (bbox ? bbox : "");
-                url += "&itemsPerPage=0";
-            }
 
             var _context = this;
 

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -578,24 +578,6 @@ define([
                 
                 return deferred.promise;
             }
-
-            // console.warn("Warning, dataset variables hardcoded to a single variable");
-            var url = this.config.hitide.externalConfigurables.variableService + "?datasetId=" + datasetId;
-
-            var _context = this;
-            xhr.get(url, {
-                headers: {
-                    "X-Requested-With": null
-                },
-                handleAs: "json",
-                method: "get"
-            }).then(function(response) {
-                deferred.resolve(response);
-            }, function(err) {
-                console.log("GranulesController – Variable request error");
-                deferred.reject(err);
-            });
-            return deferred.promise;
         },
 
         initializeVariablesGrid: function() {
@@ -661,17 +643,6 @@ define([
                 }
 
                 withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
-            }
-            else{
-                url = this.config.hitide.externalConfigurables.granuleSearchService + "?";
-                url += "datasetId=" + this.datasetId;
-                url += "&startTime=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value"));
-                url += "&endTime=" + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
-                url += "&name=" + this.nameFilterBox.get("value");
-                url += "&bbox=" + (this.bbox || "");
-                url += "&itemsPerPage=" + this.availableGranules;
-                url += "&startIndex=" + this.currentSolrIdx;
-                url += "&sort=" + this.granuleGrid._sort[0].attribute + (this.granuleGrid._sort[0].descending ? " desc" : " asc");
             }
 
             var _context = this;
@@ -774,17 +745,6 @@ define([
                 }
 
                 withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
-            }
-            else{
-                url = this.config.hitide.externalConfigurables.granuleSearchService + "?";
-                url += "datasetId=" + this.datasetId;
-                url += "&startTime=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value"));
-                url += "&endTime=" + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
-                url += "&name=" + this.nameFilterBox.get("value");
-                url += "&bbox=" + (this.bbox || "");
-                url += "&itemsPerPage=" + this.itemsPerPage;
-                url += "&startIndex=" + this.currentSolrIdx;
-                url += "&sort=" + this.granuleGrid._sort[0].attribute + (this.granuleGrid._sort[0].descending ? " desc" : " asc");
             }
 
             var _context = this;

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -138,14 +138,13 @@ define([
                 "source": _context.source,
                 "Dataset-PersistentId": _context.datasetId
             }
-            if(_context.source === "cmr"){
-                SearchVariables.search(temp_dataset).then(function(variableNames) {
-                    var variables = variableNames.map(function(variableName) {
-                        return { id: variableName }
-                    });
-                    _context.cmr_variables = variables;
+            
+            SearchVariables.search(temp_dataset).then(function(variableNames) {
+                var variables = variableNames.map(function(variableName) {
+                    return { id: variableName }
                 });
-            }
+                _context.cmr_variables = variables;
+            });
 
         },
 
@@ -234,50 +233,30 @@ define([
                     var cellContent = domConstruct.create("div", {});
                     var btn;
                     if (obj.footprint) {
-                        if(obj.source == "cmr"){
-                            if(obj["Granule-Footprint"]){
-                                btn = domConstruct.toDom("<span class='ms ms-hatch-fill granuleIcon' style='color:" + _context.datasetColor + "'></span>");
-                            }
-                            else{
-                                btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
-                            }
+                        if(obj["Granule-Footprint"]){
+                            btn = domConstruct.toDom("<span class='ms ms-hatch-fill granuleIcon' style='color:" + _context.datasetColor + "'></span>");
                         }
                         else{
-                            btn = domConstruct.toDom("<span class='ms ms-hatch-fill granuleIcon' style='color:" + _context.datasetColor + "'></span>");
-                        } 
+                            btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
+                        }
                     }
                     else {
-                        if(obj.source == "cmr"){
-                            if(obj["Granule-Footprint"]){
-                                btn = domConstruct.toDom("<span class='ms ms-stroke granuleIcon'></span>");
-                            }
-                            else{
-                                btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
-                            }
+                        if(obj["Granule-Footprint"]){
+                            btn = domConstruct.toDom("<span class='ms ms-stroke granuleIcon'></span>");
                         }
                         else{
-                            btn = domConstruct.toDom("<span class='ms ms-stroke granuleIcon'></span>");
-                        } 
+                            btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
+                        }
                     }
                     domConstruct.place(btn, cellContent);
 
-                    if(obj.source == "cmr"){
-                        if(obj["Granule-Footprint"]){
-                            on(btn, "click", function(evt) {
-                                obj.footprint = !obj.footprint;
-                                _context.gridStore.put(obj)
-                                _context.updateStateStoreObj(obj);
-                                _context.toggleFootprintDisplay(obj);
-                            });
-                        }
-                    }
-                    else{
+                    if(obj["Granule-Footprint"]){
                         on(btn, "click", function(evt) {
                             obj.footprint = !obj.footprint;
                             _context.gridStore.put(obj)
                             _context.updateStateStoreObj(obj);
                             _context.toggleFootprintDisplay(obj);
-                        });                
+                        });
                     }
 
                     return cellContent;
@@ -292,44 +271,24 @@ define([
                     var cellContent = domConstruct.create("div", {});
                     var btn;
                     if (obj.preview) {
-                        if(obj.source == "cmr"){
-                            if(obj.has_image){
-                                btn = domConstruct.toDom("<span class='fa fa-image granuleIcon' style='color:" + _context.datasetColor + "'></span>");
-                            }
-                            else{
-                                btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
-                            }
+                        if(obj.has_image){
+                            btn = domConstruct.toDom("<span class='fa fa-image granuleIcon' style='color:" + _context.datasetColor + "'></span>");
                         }
                         else{
-                            btn = domConstruct.toDom("<span class='fa fa-image granuleIcon' style='color:" + _context.datasetColor + "'></span>");
-                        } 
+                            btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
+                        }
 
                     } else {
-                        if(obj.source === "cmr"){
-                            if(obj.has_image){
-                                btn = domConstruct.toDom("<span class='fa fa-image granuleIcon'></span>");
-                            }
-                            else{
-                                btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
-                            }
+                        if(obj.has_image){
+                            btn = domConstruct.toDom("<span class='fa fa-image granuleIcon'></span>");
                         }
                         else{
-                            btn = domConstruct.toDom("<span class='fa fa-image granuleIcon'></span>");
-                        } 
+                            btn = domConstruct.toDom("<span class='fa fa-ban granuleIcon'></span>");
+                        }
                     }
                     domConstruct.place(btn, cellContent);
 
-                    if(obj.source === "cmr"){
-                        if(obj.has_image){
-                            on(btn, "click", function(evt) {
-                                obj.preview = !obj.preview;
-                                _context.gridStore.put(obj)
-                                _context.updateStateStoreObj(obj);
-                                _context.togglePreviewDisplay(obj);
-                            });
-                        }
-                    }
-                    else{
+                    if(obj.has_image){
                         on(btn, "click", function(evt) {
                             obj.preview = !obj.preview;
                             _context.gridStore.put(obj)
@@ -565,19 +524,17 @@ define([
         fetchVariables: function(datasetId, datasetShortName) {
             var deferred = new Deferred();
 
-            if(this.source === "cmr"){
-                var configPath = "dataset-configs/" + this.datasetShortName + '.cfg';
+            var configPath = "dataset-configs/" + this.datasetShortName + '.cfg';
 
-                xhr(configPath, {
-                    handleAs: "json"
-                }).then(function(obj){
-                    deferred.resolve(obj);
-                }, function(error) {
-                    deferred.reject(error);
-                });                
-                
-                return deferred.promise;
-            }
+            xhr(configPath, {
+                handleAs: "json"
+            }).then(function(obj){
+                deferred.resolve(obj);
+            }, function(error) {
+                deferred.reject(error);
+            });                
+            
+            return deferred.promise;
         },
 
         initializeVariablesGrid: function() {
@@ -616,34 +573,32 @@ define([
             var withCredentials = false;
 
             var url;
-            if(this.source === "cmr"){
 
-                var sort 
-                if(this.granuleGrid._sort[0].attribute == "Granule-StartTime"){
-                    sort = "start_date";
-                }
-                else if(this.granuleGrid._sort[0].attribute == "Granule-StopTime"){
-                    sort = "end_date";
-                }
-                else if(this.granuleGrid._sort[0].attribute ==  "Granule-Name"){
-                    sort = "readable_granule_name";
-                }
-
-                url = this.config.hitide.externalConfigurables.cmrGranuleSearchService + "?";
-                url += "collection_concept_id=" + this.datasetId;
-                url += "&bounding_box[]=" + (this.bbox || "");
-                // limit is ~2000 for page size
-                url += "&page_size=" + this.availableGranules;
-                url += "&offset=" + this.currentSolrIdx;
-                url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
-                url += "&sort_key[]=" + (this.granuleGrid._sort[0].descending ? "-" : "%2B") + sort
-                
-                if(this.nameFilterBox.get("value")){
-                    url += "&native_id[]=" + this.nameFilterBox.get("value") + "&options[native_id][pattern]=true";
-                }
-
-                withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
+            var sort 
+            if(this.granuleGrid._sort[0].attribute == "Granule-StartTime"){
+                sort = "start_date";
             }
+            else if(this.granuleGrid._sort[0].attribute == "Granule-StopTime"){
+                sort = "end_date";
+            }
+            else if(this.granuleGrid._sort[0].attribute ==  "Granule-Name"){
+                sort = "readable_granule_name";
+            }
+
+            url = this.config.hitide.externalConfigurables.cmrGranuleSearchService + "?";
+            url += "collection_concept_id=" + this.datasetId;
+            url += "&bounding_box[]=" + (this.bbox || "");
+            // limit is ~2000 for page size
+            url += "&page_size=" + this.availableGranules;
+            url += "&offset=" + this.currentSolrIdx;
+            url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
+            url += "&sort_key[]=" + (this.granuleGrid._sort[0].descending ? "-" : "%2B") + sort
+            
+            if(this.nameFilterBox.get("value")){
+                url += "&native_id[]=" + this.nameFilterBox.get("value") + "&options[native_id][pattern]=true";
+            }
+
+            withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
 
             var _context = this;
             var r;
@@ -719,33 +674,31 @@ define([
             var withCredentials = false;
 
             var url;
-            if(this.source === "cmr"){
 
-                var sort 
-                if(this.granuleGrid._sort[0].attribute == "Granule-StartTime"){
-                    sort = "start_date";
-                }
-                else if(this.granuleGrid._sort[0].attribute == "Granule-StopTime"){
-                    sort = "end_date";
-                }
-                else if(this.granuleGrid._sort[0].attribute ==  "Granule-Name"){
-                    sort = "readable_granule_name";
-                }
-
-                url = this.config.hitide.externalConfigurables.cmrGranuleSearchService + "?";
-                url += "collection_concept_id=" + this.datasetId;
-                url += "&bounding_box[]=" + (this.bbox || "");
-                url += "&page_size=" + this.itemsPerPage;
-                url += "&offset=" + this.currentSolrIdx;
-                url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
-                url += "&sort_key[]=" + (this.granuleGrid._sort[0].descending ? "-" : "%2B") + sort
-                
-                if(this.nameFilterBox.get("value")){
-                    url += "&native_id[]=" + this.nameFilterBox.get("value") + "&options[native_id][pattern]=true";
-                }
-
-                withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
+            var sort 
+            if(this.granuleGrid._sort[0].attribute == "Granule-StartTime"){
+                sort = "start_date";
             }
+            else if(this.granuleGrid._sort[0].attribute == "Granule-StopTime"){
+                sort = "end_date";
+            }
+            else if(this.granuleGrid._sort[0].attribute ==  "Granule-Name"){
+                sort = "readable_granule_name";
+            }
+
+            url = this.config.hitide.externalConfigurables.cmrGranuleSearchService + "?";
+            url += "collection_concept_id=" + this.datasetId;
+            url += "&bounding_box[]=" + (this.bbox || "");
+            url += "&page_size=" + this.itemsPerPage;
+            url += "&offset=" + this.currentSolrIdx;
+            url += "&temporal[]=" + DOMUtil.prototype.dateFormatISOBeginningOfDay(this.startDateWidget.get("value")) + "," + DOMUtil.prototype.dateFormatISOEndOfDay(this.endDateWidget.get("value"));
+            url += "&sort_key[]=" + (this.granuleGrid._sort[0].descending ? "-" : "%2B") + sort
+            
+            if(this.nameFilterBox.get("value")){
+                url += "&native_id[]=" + this.nameFilterBox.get("value") + "&options[native_id][pattern]=true";
+            }
+
+            withCredentials = this.config.hitide.externalConfigurables.crossOriginCmrCookies;
 
             var _context = this;
             var r;
@@ -791,51 +744,28 @@ define([
         },
         
         postGranulesFetch: function(response) {
-            if(this.source === "cmr"){
-                this.availableGranules = response.hits;
-                var _context = this;
-                response.items.map(function(x) {
-                    GranuleMetadata.convertFootprintAndImageFromCMR(x);
-                    var granule_id = x["meta"]["concept-id"];
-                    var fpState = _context.stateStore.get(granule_id);
-                    var previewState = _context.stateStore.get(granule_id);
+            this.availableGranules = response.hits;
+            var _context = this;
+            response.items.map(function(x) {
+                GranuleMetadata.convertFootprintAndImageFromCMR(x);
+                var granule_id = x["meta"]["concept-id"];
+                var fpState = _context.stateStore.get(granule_id);
+                var previewState = _context.stateStore.get(granule_id);
 
-                    x["Granule-DatasetId"] = _context.datasetId;
-                    x["Granule-Name"] = x["meta"]["native-id"];
+                x["Granule-DatasetId"] = _context.datasetId;
+                x["Granule-Name"] = x["meta"]["native-id"];
 
-                    x.footprint = fpState ? fpState.footprint : false;
-                    x.preview = previewState ? previewState.preview : false;
-                                     
-                    x["Granule-StartTime"] = moment.utc(x["umm"]["TemporalExtent"]["RangeDateTime"]["BeginningDateTime"]);
-                    x["Granule-StopTime"] = moment.utc(x["umm"]["TemporalExtent"]["RangeDateTime"]["EndingDateTime"]);
-                    
-                    x["source"] = "cmr";
+                x.footprint = fpState ? fpState.footprint : false;
+                x.preview = previewState ? previewState.preview : false;
+                                    
+                x["Granule-StartTime"] = moment.utc(x["umm"]["TemporalExtent"]["RangeDateTime"]["BeginningDateTime"]);
+                x["Granule-StopTime"] = moment.utc(x["umm"]["TemporalExtent"]["RangeDateTime"]["EndingDateTime"]);
+                
+                x["source"] = "cmr";
 
-                    _context.gridStore.add(x)
-                });
-            }
-            else{
-                this.availableGranules = response.response.numFound;
-                var _context = this;
-                response.response.docs.map(function(x) {
-                    // MapUtil and Terraformer don't properly handle granule footprints or extents
-                    // when they are ENVELOPE type. So, convert all ENVELOPE strings to POLYGON strings.
-                    GranuleMetadata.convertFootprintsAndExtentsFromEnvelopeToPolygon(x);
-                    // Add extra fields to response docs
-                    // Check for state in stateStore
-                    var fpState = _context.stateStore.get(x["Granule-Id"]);
-                    var previewState = _context.stateStore.get(x["Granule-Id"]);
+                _context.gridStore.add(x)
+            });
 
-                    x.footprint = fpState ? fpState.footprint : false;
-                    x.preview = previewState ? previewState.preview : false;
-                    x["Granule-StartTime"] = moment.utc(x["Granule-StartTime"]);
-                    x["Granule-StopTime"] = moment.utc(x["Granule-StopTime"]);
-
-
-                    // Add to gridStore
-                    _context.gridStore.add(x);
-                });
-            }
             this.granulesInGrid = this.gridStore.query().length;
 
             // Set no data message accordingly
@@ -982,18 +912,7 @@ define([
                 var obj = granuleObjs[i];
 
                 if (obj.footprint != active) {
-
-                    if(obj.source === "cmr"){
-                        if(obj["Granule-Footprint"]){
-                            obj.footprint = active;
-                            this.gridStore.put(obj);
-                            this.updateStateStoreObj(obj);
-
-                            // Update fp
-                            this.toggleFootprintDisplay(obj);
-                        }
-                    }
-                    else{
+                    if(obj["Granule-Footprint"]){
                         obj.footprint = active;
                         this.gridStore.put(obj);
                         this.updateStateStoreObj(obj);
@@ -1011,18 +930,7 @@ define([
                 // Update store
                 var obj = granuleObjs[i];
                 if (obj.preview != active) {
-
-                    if(obj.source === "cmr"){
-                        if(obj.has_image){
-                            obj.preview = active;
-                            this.gridStore.put(obj);
-                            this.updateStateStoreObj(obj);
-
-                            // Update preview
-                            this.togglePreviewDisplay(obj);
-                        }
-                    }
-                    else{
+                    if(obj.has_image){
                         obj.preview = active;
                         this.gridStore.put(obj);
                         this.updateStateStoreObj(obj);

--- a/src/jpl/dijit/LayerControl.js
+++ b/src/jpl/dijit/LayerControl.js
@@ -133,7 +133,12 @@ define([
                 var _context = this;
                 var url = this.config.hitide.externalConfigurables.paletteService + "/" + this.palette + ".json";
                 xhr.get(url, {
-                    handleAs: "json"
+                    handleAs: "json",     
+                    headers: {
+                        "X-Requested-With": null
+                    },
+                    method: "get",
+                    withCredentials: false
                 }).then(function(success) {
                         _context.paletteArr = success.Palette.values.value;
                         _context.drawColorbar(_context.paletteArr);

--- a/src/jpl/dijit/Search.js
+++ b/src/jpl/dijit/Search.js
@@ -244,18 +244,6 @@ define([
                 label: "Name",
                 renderCell: function(obj) {
                     var element = domConstruct.toDom("<span>" + obj["Dataset-ShortName"] + "</span>");
-                    if(obj.source === "cmr") {
-                        var cloudInfo = document.createElement('span');
-                        cloudInfo.className = 'fa fa-cloud cloudIcon cloudButton';
-                        cloudInfo.title = 'This dataset is hosted in the cloud. Click this cloud for more info.';
-                        cloudInfo.onclick = function(){
-                            var helpDialog = new HelpDialog();
-                            helpDialog.startup();
-                            helpDialog.setContentPage("helpFaq");
-                            return false;
-                        }
-                        element.appendChild(cloudInfo);
-                    }
                     return element;
                 }
             }, {

--- a/src/jpl/dijit/templates/Downloads.html
+++ b/src/jpl/dijit/templates/Downloads.html
@@ -22,23 +22,6 @@
             <input type="text" id="download-email-input" name="email" value="" data-dojo-type="dijit/form/TextBox" data-dojo-attach-point="downloadsSubmissionEmail" />
             <span data-dojo-attach-point="downloadsSubmissionEmailError" class="downloadsSubmissionEmailError">Invalid email address</span>
             <div class="downloadOptionContainer">
-                <span class="downloadOptionLabel cutAtScanlineLabel">Cut Scanline</span>
-                <div class="switch">
-                    <input data-dojo-attach-point="cutAtScanlineSelection" id="cmn-toggle-1" class="cmn-toggle cmn-toggle-round" type="checkbox">
-                    <label for="cmn-toggle-1"></label>
-                </div>
-                <span 
-                    data-dojo-attach-point="cutAtScanlineCloudWarning" 
-                    class="cutAtScanlineCloudWarning"
-                    data-toggle="tooltip" 
-                    title="Note: Cut Scanline is ALWAYS applied to subsets of cloud datasets, regardless of the position of this toggle."
-                    data-placement="right"
-                >
-                    <span class="fa fa-cloud"></span>
-                    <span class="">!</span>
-                </span>
-            </div>
-            <div class="downloadOptionContainer">
                 <span class="downloadOptionLabel mergeGranulesLabel">Merge Granules</span>
                 <div class="switch">
                     <input data-dojo-attach-point="mergeGranulesSelection" id="cmn-toggle-2" class="cmn-toggle cmn-toggle-round" type="checkbox">

--- a/src/jpl/dijit/templates/HelpDialog.html
+++ b/src/jpl/dijit/templates/HelpDialog.html
@@ -39,14 +39,14 @@
                         </div>
                         <div class="help-container help-container-hidden" id="helpFaqContent">
 
-                            <div class="helpFaqTitle">Why are there cloud icons (<span class='fa fa-cloud cloudIcon'></span>) next to certain datasets?</div>
+                            <!-- <div class="helpFaqTitle">Why are there cloud icons (<span class='fa fa-cloud cloudIcon'></span>) next to certain datasets?</div>
                             <div class="helpFaqContent">
                                 HiTIDE is migrating to the cloud and is also shifting to cloud based services for retrieving metadata
                                 and performing subsets on datasets.<br /><br />
 
                                 This migration is taking a phased approach where datasets will be transitioned in groups. Therefore, during the transition, you will be able to see both pre-transition (classic) datasets
                                 and post-transition (cloud) datasets in the dataset list. Cloud datasets can be identified by the presence of the <span class='fa fa-cloud cloudIcon'></span> icon.
-                            </div>
+                            </div> -->
 
                             <div class="helpFaqTitle">As a HiTIDE user, does it make any difference if a dataset has transitioned to the cloud services or not?</div>
                             <div class="helpFaqContent">
@@ -95,7 +95,7 @@
                                     The information provided by users when they register for Earthdata Login helps NASA better understand how our data are being used and the diverse needs of multiple user communities. This helps us prioritize improvements in data discovery, access, and usability. Registration also allows us to inform users with pertinent information such as the availability of new or updated data products, or data quality issues. In the future, it will allow for new value-added features and customized services resulting in a better user experience. For questions regarding Earthdata Login, see <a href="https://urs.earthdata.nasa.gov/documentation">https://urs.earthdata.nasa.gov/documentation</a>.
                             </div>
 
-                            <div class="helpFaqTitle">What does the "Cut Scanline" download option mean?</div>
+                            <!-- <div class="helpFaqTitle">What does the "Cut Scanline" download option mean?</div>
                             <div class="helpFaqContent">Swath data are often captured in scanlines. Because HiTIDE allows users to specify custom regions of interest, this presents a dilemma when subsetting the data. Some users want only the data within their region of interest, and nothing else. Other users want the entire scanline, regardless of if it all falls within their region of interest. To this end, HiTIDE allows the option to “cut scanlines” at the granule download screen.
                                 <br>
                                 <br>
@@ -113,7 +113,11 @@
                                     <br>
                                     <br>The red box is the bounding box used to subset, and the blue boxes are shortened scanlines that intersect with the red box. The data in the blue boxes within the red box will be including in the subsetted result. The data in the blue boxes outside of the red box will be changed to No Value and included in the subsetted result. The original scanline width has been shortened to reduce the data size.
                                 </span>
-                            </div>
+                            </div> -->
+
+                            <div class="helpFaqTitle">Where did the "Cut Scanline" download option go?</div>
+                            <div class="helpFaqContent">The Cut Scanline feature is now always applied when subsetting datasets in HiTIDE. The download option has been depreciated since classic datasets have been phased out and replaced by cloud datasets. We automatically cut the scanline for you meaning that you download only your region of interest after it is subsetted.</div>
+
                             <div class="helpFaqTitle">What does the "Merge Granules" download option mean?</div>
                             <div class="helpFaqContent">
                                 By enabling the "Merge Granules" download option in the "Downloads" tab, all of the subsetted granules for a given job will be merged into a single NetCDF4 granule. This granule will have an additional index called "subset_index" added to the variables. This index maps the file from which the subsetter portion of the data comes. For example, if you have 50 files in your subset region, merging them will give you a single file back with an "subset_index" (50) for each variable found in the original files. This file is meant to be easier to work with instead of multiple individual files.

--- a/src/jpl/dijit/ui/MetadataDialog.js
+++ b/src/jpl/dijit/ui/MetadataDialog.js
@@ -13,7 +13,7 @@ define([
     "dojo/_base/window",
     "jpl/config/Config",
     "moment/moment",
-    "jpl/utils/SearchVariables"
+    "jpl/utils/SearchVariables",
 ], function(declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, template, css,
     VariableListing, DatasetAvailability, domAttr, domConstruct, query, win, Config, 
     moment, SearchVariables) {

--- a/src/jpl/utils/GranuleAvailability/CombinedAvailabilityApi.js
+++ b/src/jpl/utils/GranuleAvailability/CombinedAvailabilityApi.js
@@ -7,7 +7,6 @@ define([
   return declare(null, {
     constructor: function (options) {
       this.cmr = options.cmrAvailabilityApi;
-      this.l2ss = options.l2ssAvailabilityApi;
     },
 
     fetchAvailability: function (startTime, endTime, gap, datasets) {
@@ -19,8 +18,6 @@ define([
         var id = dataset["Dataset-PersistentId"];
         if (dataset.source === "cmr") {
           return _context.cmr.fetchOne(startTimeString, endTimeString, gap, id);
-        } else {
-          return _context.l2ss.fetchOne(startTimeString, endTimeString, gap, id);
         }
       });
       return all(requestPromises);

--- a/src/jpl/utils/GranuleAvailability/CombinedAvailabilityApi.js
+++ b/src/jpl/utils/GranuleAvailability/CombinedAvailabilityApi.js
@@ -16,9 +16,7 @@ define([
       var _context = this;
       var requestPromises = Object.values(datasets).map(function (dataset) {
         var id = dataset["Dataset-PersistentId"];
-        if (dataset.source === "cmr") {
-          return _context.cmr.fetchOne(startTimeString, endTimeString, gap, id);
-        }
+        return _context.cmr.fetchOne(startTimeString, endTimeString, gap, id);
       });
       return all(requestPromises);
     }

--- a/src/jpl/utils/JPLTour.js
+++ b/src/jpl/utils/JPLTour.js
@@ -350,7 +350,7 @@ define([
             }, {
                 title: "Submit Download Job",
                 element: "#downloadsSubmissionButton",
-                content: 'Once you are logged in, downloads will be enabled. HiTIDE will fill in an email address for you to receive notifications of job completion. You can also enter an alternate email address. Then click <b>Download Selected Granules</b> to start the download.<br><br><i>Note: to learn more about the "cut scanline" and "merge granules" options, visit the FAQs in the Help section.</i>',
+                content: 'Once you are logged in, downloads will be enabled. HiTIDE will fill in an email address for you to receive notifications of job completion. You can also enter an alternate email address. Then click <b>Download Selected Granules</b> to start the download.<br><br><i>Note: to learn more about the "merge granules" options, visit the FAQs in the Help section.</i>',
                 placement: "left",
                 onShow: function(tour) {
                     // Go to Granule Selection

--- a/src/jpl/utils/SearchDatasets.js
+++ b/src/jpl/utils/SearchDatasets.js
@@ -126,25 +126,43 @@ define([
 
     function getCmrSpatialExtent(datasetObject){
         var conceptId = datasetObject["Dataset-PersistentId"]
-        var url = config.hitide.externalConfigurables.cmrVariableService;
-        var customQuery = "{\n collection (conceptId: \"" + conceptId + "\") {\n spatialExtent \n} \n}"
-
-        return request.post(url, {
+        // var url = config.hitide.externalConfigurables.cmrVariableService;
+        // var customQuery = "{\n collection (conceptId: \"" + conceptId + "\") {\n spatialExtent \n} \n}"
+        var secondURL = config.hitide.externalConfigurables.cmrCollectionSearchService + "/" + conceptId + ".umm_json"
+        return request(secondURL, {
             handleAs: 'json',
-            withCredentials: config.hitide.externalConfigurables.crossOriginCmrCookies,
-            headers: { "X-Requested-With": null, "Content-Type": "application/json" },
-            data: JSON.stringify({ query: customQuery })
+            headers: {
+                "X-Requested-With": null
+            },
+            withCredentials: config.hitide.externalConfigurables.crossOriginCmrCookies
         }).then(function(response) {
-            var resolutionAndCoordinateSystemObject = response.data.collection.spatialExtent.horizontalSpatialDomain.resolutionAndCoordinateSystem
+            var resolutionAndCoordinateSystemObject = response.SpatialExtent.HorizontalSpatialDomain.ResolutionAndCoordinateSystem
             if (resolutionAndCoordinateSystemObject) {
-                var resolutionObject = resolutionAndCoordinateSystemObject.horizontalDataResolution.genericResolutions[0]
+                var resolutionObject = resolutionAndCoordinateSystemObject.HorizontalDataResolution.GenericResolutions[0]
                 if (resolutionObject) {
-                    datasetObject["Dataset-AcrossTrackResolution"] = resolutionObject.xDimension
-                    datasetObject["Dataset-AlongTrackResolution"] = resolutionObject.yDimension
+                    datasetObject["Dataset-AcrossTrackResolution"] = resolutionObject.XDimension
+                    datasetObject["Dataset-AlongTrackResolution"] = resolutionObject.YDimension
                 }
             }
             return datasetObject
         })
+        // NOTE: Example of Graphql implementation of above query
+        // return request.post(url, {
+        //     handleAs: 'json',
+        //     withCredentials: config.hitide.externalConfigurables.crossOriginCmrCookies,
+        //     headers: { "X-Requested-With": null, "Content-Type": "application/json" },
+        //     data: JSON.stringify({ query: customQuery })
+        // }).then(function(response) {
+        //     var resolutionAndCoordinateSystemObject = response.data.collection.spatialExtent.horizontalSpatialDomain.resolutionAndCoordinateSystem
+        //     if (resolutionAndCoordinateSystemObject) {
+        //         var resolutionObject = resolutionAndCoordinateSystemObject.horizontalDataResolution.genericResolutions[0]
+        //         if (resolutionObject) {
+        //             datasetObject["Dataset-AcrossTrackResolution"] = resolutionObject.xDimension
+        //             datasetObject["Dataset-AlongTrackResolution"] = resolutionObject.yDimension
+        //         }
+        //     }
+        //     return datasetObject
+        // })
     }
 
     function getAdditionalCmrMetadata(collectionObjectArray) {

--- a/src/jpl/utils/SearchVariables.js
+++ b/src/jpl/utils/SearchVariables.js
@@ -8,7 +8,7 @@ define([
     /**
      * 
      * @param {Object} dataset 
-     * @param {string} dataset.source (optional) l2ss or cmr
+     * @param {string} dataset.source (optional) cmr
      * @param {string} dataset [\"Dataset-PersistentId\"]
      * 
      * @returns dojo promise containing response or error
@@ -21,22 +21,6 @@ define([
         if(dataset.source === 'cmr') {
             return searchCmr(dataset);
         }
-        else {
-            return searchL2ss(dataset);
-        }
-    }
-
-    function searchL2ss(dataset) {
-        var url = config.hitide.externalConfigurables.variableService + "?datasetId=" + dataset["Dataset-PersistentId"];
-        return request(url, {
-            handleAs: 'json',
-            headers: { "X-Requested-With": null }
-        }).then(function(response) {
-            response.variables.sort(function (a, b) {
-                return a.toLowerCase().localeCompare(b.toLowerCase());
-            });
-            return response.variables;
-        });
     }
 
     function searchCmr(dataset, customQuery) {

--- a/src/jpl/utils/SearchVariables.js
+++ b/src/jpl/utils/SearchVariables.js
@@ -39,13 +39,17 @@ define([
         });
     }
 
-    function searchCmr(dataset) {
+    function searchCmr(dataset, customQuery) {
         // This function uses the cmr graphql api, since this allows getting
         // all the variable names for a collection in one request
         var url = config.hitide.externalConfigurables.cmrVariableService;
 
         var templateQuery = "{\n  collection (conceptId:\"{COLLECTION_ID}\") {\n    shortName\n    variables {\n      items {\n        name\n      }\n    }\n  }\n}"
+          
         var query = templateQuery.replace("{COLLECTION_ID}", dataset['Dataset-PersistentId']);
+        if (customQuery) {
+            query = customQuery
+        }
         
         return request.post(url, {
             handleAs: 'json',
@@ -68,7 +72,6 @@ define([
         });
     }
 
-    
     return {
         search: search
     };


### PR DESCRIPTION
### Changes
- removed references to l2ss
- getting cloud resolution metedata using normal get instead of graphql because it is faster
- removed cloud icons from datasets
- removed cut scanline option in download options tab
- changed FAQ references to cloud icon and cut scanline
- fixed color palette error in legend when selecting datasets
