### PR TITLE
Release/4.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - issue-15: Getting cloud resolution metedata using normal get instead of graphql because it is faster
 - issue-15: Changed FAQ references to cloud icon and cut scanline
 ### Removed
-- issue-15: Removed references to l2ss
+- issue-15: Removed references to on-prem l2ss
 - issue-15: Removed cloud icons from datasets
 - issue-15: Removed cut scanline option in download options tab
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - issue-15: Removed cloud icons from datasets
 - issue-15: Removed cut scanline option in download options tab
 ### Fixed
-- issue-15: Fixed color palette error in legend when selecting datasets
-
+- issue-15: Fixed color palette error in the legend when selecting datasets
+gi
 ## [4.15.0]
 ### Added
 - issue-17: Add way to read config files to allow for multiple lat lon for variables images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+### Removed
+### Fixed
+
+
+## [4.16.0]
+### Added
+### Changed
 - issue-15: Getting cloud resolution metedata using normal get instead of graphql because it is faster
 - issue-15: Changed FAQ references to cloud icon and cut scanline
 ### Removed
@@ -15,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - issue-15: Removed cut scanline option in download options tab
 ### Fixed
 - issue-15: Fixed color palette error in the legend when selecting datasets
-gi
+
+
 ## [4.15.0]
 ### Added
 - issue-17: Add way to read config files to allow for multiple lat lon for variables images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-- issue-15: getting cloud resolution metedata using normal get instead of graphql because it is faster
-- issue-15: changed FAQ references to cloud icon and cut scanline
+- issue-15: Getting cloud resolution metedata using normal get instead of graphql because it is faster
+- issue-15: Changed FAQ references to cloud icon and cut scanline
 ### Removed
-- issue-15: removed references to l2ss
-- issue-15: removed cloud icons from datasets
-- issue-15: removed cut scanline option in download options tab
+- issue-15: Removed references to l2ss
+- issue-15: Removed cloud icons from datasets
+- issue-15: Removed cut scanline option in download options tab
 ### Fixed
-- issue-15: fixed color palette error in legend when selecting datasets
+- issue-15: Fixed color palette error in legend when selecting datasets
 
 ## [4.15.0]
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-rc.3",
+  "version": "4.16.0-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-rc.5",
+  "version": "4.16.0-rc.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0",
+  "version": "4.16.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-rc.1",
+  "version": "4.16.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-3",
+  "version": "4.16.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-1",
+  "version": "4.16.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-2",
+  "version": "4.16.0-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-rc.4",
+  "version": "4.16.0-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
-  "version": "4.16.0-rc.2",
+  "version": "4.16.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-rc.2",
+  "version": "4.16.0-rc.3",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0",
+  "version": "4.16.0-1",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-2",
+  "version": "4.16.0-3",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-rc.5",
+  "version": "4.16.0-rc.6",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-rc.4",
+  "version": "4.16.0-rc.5",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-rc.1",
+  "version": "4.16.0-rc.2",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-3",
+  "version": "4.16.0-rc.1",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-rc.3",
+  "version": "4.16.0-rc.4",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@gov.nasa.jpl.podaac/hitide-ui",
   "title": "HiTIDE",
   "description": "High Level Tool for Interactive Data Extraction",
-  "version": "4.16.0-1",
+  "version": "4.16.0-2",
   "scripts": {
     "build": "grunt --force; npm run copy",
     "copy": "node scripts/copy-files.js",

--- a/src/jpl/dijit/Downloads.js
+++ b/src/jpl/dijit/Downloads.js
@@ -117,10 +117,9 @@ define([
                 // Assemble job
                 var subjobs = this.downloadsListing.getDownloadQueryObjs();
                 var downloadOptions = {
-                    cutAtScanline: this.cutAtScanlineSelection.checked,
                     mergeGranules: this.mergeGranulesSelection.checked
                 };
-                
+                console.log(subjobs)
                 for (var subjobId in subjobs) {
                     if (subjobs.hasOwnProperty(subjobId)) {
                         var subjob = subjobs[subjobId];

--- a/src/jpl/dijit/Search.js
+++ b/src/jpl/dijit/Search.js
@@ -129,17 +129,7 @@ define([
                 var facets = results.facets;
                 _context.facetSelector.addFacetItems(facets);
                 _context.searchFacetTagContainer.addFacetItems(facets);
-
-                // Populate search results with initial results from date range and region
-                var datasets = results.datasets;
-                var obj = {};
-                datasets.forEach(function(val) {
-                    obj[val["Dataset-PersistentId"]] = val;
-                });
-                _context.initialSearch = obj;
-                topic.publish(SearchEvent.prototype.SEARCH_LOADED, {
-                    success: true
-                });
+                _context.setInitialSearch(results.datasets)
             }, function(error) {
                 new AlertDialog({
                     alertTitle: "Server Error",
@@ -297,6 +287,17 @@ define([
             }));
         },
 
+        setInitialSearch: function(data) {
+            var obj = {};
+            data.forEach(function(val) {
+                obj[val["Dataset-PersistentId"]] = val;
+            });
+            this.initialSearch = obj;
+            topic.publish(SearchEvent.prototype.SEARCH_LOADED, {
+                success: true
+            });
+        },
+
         windowResized: function(message) {
             // Resize table
             domStyle.set(this.datasetGrid.domNode, "height", (document.body.clientHeight - 700) + 210 + "px");
@@ -383,6 +384,19 @@ define([
             this.fetchDatasets().then(lang.hitch(this, function(response) {
                 // Format results
                 var data = _context.formatDatasetResponse(response.response.docs);
+                if (resetDatasets) {
+                    // set _context.initialSearch again
+                    this.setInitialSearch(data)
+                    var datasets = data;
+                    var obj = {};
+                    datasets.forEach(function(val) {
+                        obj[val["Dataset-PersistentId"]] = val;
+                    });
+                    _context.initialSearch = obj;
+                    topic.publish(SearchEvent.prototype.SEARCH_LOADED, {
+                        success: true
+                    });
+                }
                 this.updateDatasetGrid(response, data);
                 this.updateFacetSelector(response);
                 if (resetDatasets) {

--- a/src/jpl/dijit/templates/HelpDialog.html
+++ b/src/jpl/dijit/templates/HelpDialog.html
@@ -157,6 +157,16 @@
                         <div class="help-container help-container-hidden" id="helpReleaseNotesContent">
                             <div>
                                 <div class="helpReleaseNotesVersionTitle">
+                                    <b>Version 4.16.0</b> (9/7/2023)
+                                </div>
+                                <ul>
+                                    <li><span class="releaseNotesTag releaseNotesTagFixed">Fixed</span> Dataset Information: <b>Spatial Resolution</b> now displaying properly.</li>
+                                    <li><span class="releaseNotesTag releaseNotesTagNew">New!</span> All Datasets are now <i>only</i> in the Cloud, also removed Cloud icon.</li>
+                                    <li><span class="releaseNotesTag releaseNotesTagNew">New!</span> Removed <i>Cut Scanline</i> option from Downloads section.  Cut scanline is now <i>always</i> applied.</li>
+                                </ul>
+                            </div>
+                            <div>
+                                <div class="helpReleaseNotesVersionTitle">
                                     <b>Version 4.15.0</b> (7/18/2023)
                                 </div>
                                 <ul>

--- a/src/jpl/dijit/templates/HelpDialog.html
+++ b/src/jpl/dijit/templates/HelpDialog.html
@@ -116,7 +116,7 @@
                             </div> -->
 
                             <div class="helpFaqTitle">Where did the "Cut Scanline" download option go?</div>
-                            <div class="helpFaqContent">The Cut Scanline feature is now always applied when subsetting datasets in HiTIDE. The download option has been depreciated since classic datasets have been phased out and replaced by cloud datasets. We automatically cut the scanline for you meaning that you download only your region of interest after it is subsetted.</div>
+                            <div class="helpFaqContent">The Cut Scanline feature is now always applied when subsetting datasets in HiTIDE. This download option has been removed since classic datasets have been phased out and replaced by cloud datasets. We automatically cut the scanline for you meaning that you download only your region of interest after it is subsetted.</div>
 
                             <div class="helpFaqTitle">What does the "Merge Granules" download option mean?</div>
                             <div class="helpFaqContent">

--- a/src/jpl/dijit/templates/HelpDialog.html
+++ b/src/jpl/dijit/templates/HelpDialog.html
@@ -161,8 +161,8 @@
                                 </div>
                                 <ul>
                                     <li><span class="releaseNotesTag releaseNotesTagFixed">Fixed</span> Dataset Information: <b>Spatial Resolution</b> now displaying properly.</li>
-                                    <li><span class="releaseNotesTag releaseNotesTagNew">New!</span> All Datasets are now <i>only</i> in the Cloud, also removed Cloud icon.</li>
-                                    <li><span class="releaseNotesTag releaseNotesTagNew">New!</span> Removed <i>Cut Scanline</i> option from Downloads section.  Cut scanline is now <i>always</i> applied.</li>
+                                    <li><span class="releaseNotesTag releaseNotesTagNew">New!</span> All Datasets are now in the Cloud, also removed Cloud icon.</li>
+                                    <li><span class="releaseNotesTag releaseNotesTagNew">New!</span> Removed <b><i>Cut Scanline</i></b> option from Downloads section.  Cut scanline is now <i>always</i> applied.</li>
                                 </ul>
                             </div>
                             <div>

--- a/src/jpl/dijit/ui/MetadataDialog.js
+++ b/src/jpl/dijit/ui/MetadataDialog.js
@@ -13,7 +13,7 @@ define([
     "dojo/_base/window",
     "jpl/config/Config",
     "moment/moment",
-    "jpl/utils/SearchVariables",
+    "jpl/utils/SearchVariables"
 ], function(declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, template, css,
     VariableListing, DatasetAvailability, domAttr, domConstruct, query, win, Config, 
     moment, SearchVariables) {

--- a/src/jpl/dijit/ui/MetadataDialog.js
+++ b/src/jpl/dijit/ui/MetadataDialog.js
@@ -88,6 +88,7 @@ define([
                 domAttr.set(this.metadataAlongAcrossRes, "innerHTML", "Not Available");
 
             /* Set date range */
+            console.log(metadata)
             var startDate = metadata["DatasetCoverage-StartTimeLong"];
             var formattedStart = "Unknown";
             if (startDate) {


### PR DESCRIPTION
## [4.16.0]
### Added
### Changed
- issue-15: Getting cloud resolution metedata using normal get instead of graphql because it is faster
- issue-15: Changed FAQ references to cloud icon and cut scanline
### Removed
- issue-15: Removed references to l2ss
- issue-15: Removed cloud icons from datasets
- issue-15: Removed cut scanline option in download options tab
### Fixed
- issue-15: Fixed color palette error in the legend when selecting datasets
