### PR TITLE
Fix/hitide UI 38 - fix variables not loading

### DIFF
--- a/src/jpl/dijit/ui/MetadataDialog.js
+++ b/src/jpl/dijit/ui/MetadataDialog.js
@@ -119,7 +119,8 @@ define([
                 domAttr.set(this.metadataAlongAcrossRes, "innerHTML", resolutionString);
             }
             else
-                domAttr.set(this.metadataAlongAcrossRes, "innerHTML", "Not Available");
+                // domAttr.set(this.metadataAlongAcrossRes, "innerHTML", "Not Available");
+                domAttr.set(this.metadataAlongAcrossRes, "innerHTML", "Not Applicable");
 
             /* Set date range */
             var startDate = metadata["DatasetCoverage-StartTimeLong"];

--- a/src/jpl/utils/SearchVariables.js
+++ b/src/jpl/utils/SearchVariables.js
@@ -28,7 +28,7 @@ define([
         // all the variable names for a collection in one request
         var url = config.hitide.externalConfigurables.cmrVariableService;
 
-        var templateQuery = "{\n  collection (conceptId:\"{COLLECTION_ID}\") {\n    shortName\n    variables {\n      items {\n        name\n      }\n    }\n  }\n}"
+        var templateQuery = "{\n  collection (conceptId:\"{COLLECTION_ID}\") {\n    variables {\n      items {\n        name\n      }\n    }\n  }\n}"
           
         var query = templateQuery.replace("{COLLECTION_ID}", dataset['Dataset-PersistentId']);
         if (customQuery) {


### PR DESCRIPTION
### Changes

- removed shortName retrieval operation from variable graphql query

### Reasoning for initial bug

- Could be because cmr changed the graphql schema (last change about a month ago)

### Related issues
#38 