### PR TITLE
Issue/hitide UI 68 - fix dataset ui crash bug

### DIFF
--- a/src/jpl/utils/SearchDatasets.js
+++ b/src/jpl/utils/SearchDatasets.js
@@ -159,14 +159,18 @@ define([
         var resolutionAndCoordinateSystemObject = additionalMetadataObject.spatialExtent.horizontalSpatialDomain.resolutionAndCoordinateSystem
         var relatedUrlsArray = additionalMetadataObject.relatedUrls
         if (resolutionAndCoordinateSystemObject) {
-            var resolutionObjects = resolutionAndCoordinateSystemObject.horizontalDataResolution.genericResolutions
+            var resolutionObjects = resolutionAndCoordinateSystemObject.horizontalDataResolution
             if (resolutionObjects) {
-                resolutionObjects.forEach(function(resolutionObject) {
-                    var acrossTrack = resolutionObject.xdimension
-                    var alongTrack = resolutionObject.ydimension
-                    var unit = resolutionObject.unit
-                    datasetObject["Dataset-Resolution"].push({"Dataset-AcrossTrackResolution": acrossTrack, "Dataset-AlongTrackResolution": alongTrack, "Unit": unit})
-                });
+                if(resolutionObjects.genericResolutions) {
+                    resolutionObjects.genericResolutions.forEach(function(resolutionObject) {
+                        var acrossTrack = resolutionObject.xdimension
+                        var alongTrack = resolutionObject.ydimension
+                        var unit = resolutionObject.unit
+                        datasetObject["Dataset-Resolution"].push({"Dataset-AcrossTrackResolution": acrossTrack, "Dataset-AlongTrackResolution": alongTrack, "Unit": unit})
+                    });
+                } else {
+                    datasetObject["Dataset-Resolution"].push({"error": "Not Available"})
+                }
             } else {
                 // Resolution not available by error
                 datasetObject["Dataset-Resolution"].push({"error": "Not Available"})

--- a/src/jpl/utils/SearchDatasets.js
+++ b/src/jpl/utils/SearchDatasets.js
@@ -172,7 +172,7 @@ define([
                     datasetObject["Dataset-Resolution"].push({"error": "Not Available"})
                 }
             } else {
-                // Resolution not available by error.
+                // Resolution not available by error
                 datasetObject["Dataset-Resolution"].push({"error": "Not Available"})
             }
         } else {

--- a/src/jpl/utils/SearchDatasets.js
+++ b/src/jpl/utils/SearchDatasets.js
@@ -172,7 +172,7 @@ define([
                     datasetObject["Dataset-Resolution"].push({"error": "Not Available"})
                 }
             } else {
-                // Resolution not available by error
+                // Resolution not available by error.
                 datasetObject["Dataset-Resolution"].push({"error": "Not Available"})
             }
         } else {


### PR DESCRIPTION
### Changes
- Fixed error handling of metadata missing to prevent erroring out

### Related
- Issue tracked in #68 

### Testing
- Not working in SIT
- Working in UAT

### TODO
- Handle database error gracefully so frontend doesn't crash