### PR TITLE
feature/hitide-ui-65: fixed thumbnails and footprints disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+- issue-65: Fixed footprints and previews disappearing from map when not intended
 
 
 ## [4.17.1]

--- a/src/hitideConfig.js
+++ b/src/hitideConfig.js
@@ -1,4 +1,5 @@
 var hitideProfileOrigin = "https://hitide.profile.podaac.uat.earthdatacloud.nasa.gov/hitide/api";
+// var hitideProfileOrigin = "http://localhost:8080/hitide/api";
 
 window.hitideConfig = {
     paletteService: "https://hitide.podaac.earthdatacloud.nasa.gov/palettes",
@@ -10,7 +11,7 @@ window.hitideConfig = {
     cmrVariableService: hitideProfileOrigin + "/cmr/graphql",
     crossOriginCmrCookies: true,
 
-    authCodeUrl: "https://uat.urs.earthdata.nasa.gov/oauth/authorize",
+    authCodeUrl: "https://urs.earthdata.nasa.gov/oauth/authorize",
 
     loginUrl: hitideProfileOrigin + "/session/login",
     logoutUrl: hitideProfileOrigin + "/session/logout",
@@ -24,5 +25,5 @@ window.hitideConfig = {
     datasetSearchServiceItemsPerPage: 200,
     maxGranulesPerDownload: 999999999,
     googleTagManagerId: "GTM-M5D83V6",
-    earthDataAppClientId: "dxpH2WeN_f8IpNLgHwplsg"
+    earthDataAppClientId: "mn6VmRfej3U2Tm0UhbC1jw"
 };

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -757,15 +757,7 @@ define([
                     stateStoreItemsToRemove.push((currentStateStore[j]))
                 }
             }
-            for(var k=0; k<stateStoreItemsToRemove.length; k++) {
-                _context.stateStore.remove(stateStoreItemsToRemove[k]["Granule-Id"])
-                topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_FOOTPRINT, {
-                    granuleObj: stateStoreItemsToRemove[k]
-                });
-                topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_PREVIEW, {
-                    granuleObj: stateStoreItemsToRemove[k]
-                });
-            }
+
             // clear anything from state store that is not a concept id in the response items
             response.items.map(function(x) {
                 GranuleMetadata.convertFootprintAndImageFromCMR(x);

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -78,6 +78,7 @@ define([
         _granuleSearchInProgress: false,
         loadingGranulesMessage: '<div class="granulesControllerLoadingGranulesMessage">Loading Granules...</div>',
         noGranulesMessage: '<div class="granulesControllerNoDataMessage">No Granules Found</div>',
+        scrollLoadInProgress: false,
 
         constructor: function() {
             this.datasetVariables = {};
@@ -757,7 +758,18 @@ define([
                     stateStoreItemsToRemove.push((currentStateStore[j]))
                 }
             }
-
+            // if scroll, don't remove
+            if(!this.scrollLoadInProgress) {
+                for(var k=0; k<stateStoreItemsToRemove.length; k++) {
+                    _context.stateStore.remove(stateStoreItemsToRemove[k]["Granule-Id"])
+                    topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_FOOTPRINT, {
+                        granuleObj: stateStoreItemsToRemove[k]
+                    });
+                    topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_PREVIEW, {
+                        granuleObj: stateStoreItemsToRemove[k]
+                    });
+                }
+            }
             // clear anything from state store that is not a concept id in the response items
             response.items.map(function(x) {
                 GranuleMetadata.convertFootprintAndImageFromCMR(x);
@@ -830,6 +842,9 @@ define([
             // Show spinner 
             this.displayLoadingSpinner(false);
 
+            // set scroll back to false
+            this.scrollLoadInProgress = false;
+
         },
 
         filterGranules: function() {
@@ -884,6 +899,7 @@ define([
             // First approach, fetch more if scroll pos is 90% of way down
             if ((scrollPosTop + offsetHeight) / scrollHeight > 0.90) {
                 this.currentSolrIdx += this.itemsPerPage;
+                this.scrollLoadInProgress = true;
                 this.fetchGranules();
             }
         },


### PR DESCRIPTION
### Changes

- removed code that was removing thumbnails and footprints whenever the postGranuleFetch ran which was after scrolling and filtering.