### PR TITLE
issue/hitide-ui-65: fixed previews/footprints not staying on map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
-- issue-65: Fixed footprints and previews disappearing from map when not intended
+- issue-65: Fixed footprints and previews disappearing from map when not intended and staying on when selected but the granule is not in current list.
 
 
 ## [4.17.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
-- issue-65: Fixed footprints and previews disappearing from map when not intended and staying on when selected but the granule is not in current list.
+- issue-65: Fixed footprints and previews disappearing from map when not intended and staying on too long.
 
 
 ## [4.17.2]

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -417,9 +417,7 @@ define([
                 label: "Clear all footprints",
                 iconClass: "fa fa-trash color-orange",
                 onClick: function(evt) {
-                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedFootprintStore)).filter(function(x) {
-                        return x.footprint
-                    }).map(function(obj){
+                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedFootprintStore)).map(function(obj){
                         obj.footprint = false
                         _context.gridStore.put(obj)
                         _context.updateStateStoreObj(obj);
@@ -490,9 +488,7 @@ define([
                 label: "Clear all image previews",
                 iconClass: "fa fa-trash color-orange",
                 onClick: function(evt) {
-                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedPreviewStore)).filter(function(x) {
-                        return x.preview
-                    }).map(function(obj){
+                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedPreviewStore)).map(function(obj){
                         obj.preview = false
                         _context.gridStore.put(obj)
                         _context.updateStateStoreObj(obj);

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -416,16 +416,30 @@ define([
             contextMenu.addChild(new MenuItem({
                 label: "Clear all footprints",
                 iconClass: "fa fa-trash color-orange",
+                // .concat(Object.values(_context.addedFootprintStore))
                 onClick: function(evt) {
-                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedFootprintStore)).map(function(obj){
+                    var stateStoreObjects = Array.from(_context.stateStore.query()).map(function(obj){
                         obj.footprint = false
                         _context.gridStore.put(obj)
                         _context.updateStateStoreObj(obj);
                         _context.toggleFootprintDisplay(obj);
                         return obj
                     })
-                    _context.toggleFootprints(stateStoreObjects, false);
-                    // remove from addedFootprints and from addedPreviews
+                    var gridStoreObjects = Array.from(_context.gridStore.query()).map(function(obj){
+                        obj.footprint = false
+                        _context.gridStore.put(obj)
+                        _context.updateStateStoreObj(obj);
+                        return obj
+                    })
+                    var addedFootprintObjects = Object.values(_context.addedFootprintStore).map(function(obj){
+                        obj.footprint = false
+                        _context.gridStore.put(obj)
+                        _context.updateStateStoreObj(obj);
+                        _context.toggleFootprintDisplay(obj);
+
+                        return obj
+                    })
+                    _context.toggleFootprints(stateStoreObjects.concat(gridStoreObjects).concat(addedFootprintObjects), false);
                     _context.addedFootprintStore = {};
                 }
             }));
@@ -488,14 +502,27 @@ define([
                 label: "Clear all image previews",
                 iconClass: "fa fa-trash color-orange",
                 onClick: function(evt) {
-                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedPreviewStore)).map(function(obj){
+                    var stateStoreObjects = Array.from(_context.stateStore.query()).map(function(obj){
                         obj.preview = false
                         _context.gridStore.put(obj)
                         _context.updateStateStoreObj(obj);
                         _context.togglePreviewDisplay(obj);
                         return obj
                     })
-                    _context.togglePreviews(stateStoreObjects, false);
+                    var gridStoreObjects = Array.from(_context.gridStore.query()).map(function(obj){
+                        obj.preview = false
+                        _context.gridStore.put(obj)
+                        _context.updateStateStoreObj(obj);
+                        return obj
+                    })
+                    var addedPreviewObjects = Object.values(_context.addedPreviewStore).map(function(obj){
+                        obj.preview = false
+                        _context.gridStore.put(obj)
+                        _context.updateStateStoreObj(obj);
+                        _context.togglePreviewDisplay(obj);
+                        return obj
+                    })
+                    _context.togglePreviews(stateStoreObjects.concat(gridStoreObjects).concat(addedPreviewObjects), false);
                     // remove from addedPreviews
                     _context.addedPreviewStore = {};
                 }

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -79,6 +79,8 @@ define([
         loadingGranulesMessage: '<div class="granulesControllerLoadingGranulesMessage">Loading Granules...</div>',
         noGranulesMessage: '<div class="granulesControllerNoDataMessage">No Granules Found</div>',
         scrollLoadInProgress: false,
+        addedFootprintStore: {},
+        addedPreviewStore: {},
 
         constructor: function() {
             this.datasetVariables = {};
@@ -762,12 +764,6 @@ define([
             if(!this.scrollLoadInProgress) {
                 for(var k=0; k<stateStoreItemsToRemove.length; k++) {
                     _context.stateStore.remove(stateStoreItemsToRemove[k]["Granule-Id"])
-                    topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_FOOTPRINT, {
-                        granuleObj: stateStoreItemsToRemove[k]
-                    });
-                    topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_PREVIEW, {
-                        granuleObj: stateStoreItemsToRemove[k]
-                    });
                 }
             }
             // clear anything from state store that is not a concept id in the response items
@@ -799,6 +795,19 @@ define([
 
                 x.footprint = fpState ? fpState : false;
                 x.preview = previewState ? previewState : false;
+
+                // if(_context.addedFootprintStore.map(function(i){
+                //     return i["Granule-Name"]
+                // }).includes(x['Granule-Name'])) {
+                //     x.footprint = true
+                // }
+                if(Object.keys(_context.addedFootprintStore).includes(x['Granule-Name'])) {
+                    x.footprint = true
+                }
+
+                if(Object.keys(_context.addedPreviewStore).includes(x['Granule-Name'])) {
+                    x.preview = true
+                }
                                     
                 x["Granule-StartTime"] = moment.utc(x["umm"]["TemporalExtent"]["RangeDateTime"]["BeginningDateTime"]);
                 x["Granule-StopTime"] = moment.utc(x["umm"]["TemporalExtent"]["RangeDateTime"]["EndingDateTime"]);
@@ -943,7 +952,6 @@ define([
 
         toggleFootprintDisplay: function(obj) {
             if (obj.footprint) {
-                // if (!this.footprintGraphics[obj["Granule-Id"]]) {
                 var rgb = this.hexToRgb(this.datasetColor);
                 var borderColor = [rgb.r, rgb.g, rgb.b, 0.7];
                 var fillColor = [rgb.r, rgb.g, rgb.b, 0.00];
@@ -952,10 +960,20 @@ define([
                     border: borderColor,
                     fill: fillColor
                 });
+                // add to my separate store
+                this.addedFootprintStore[obj["Granule-Name"]] = obj;
             } else {
                 topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_FOOTPRINT, {
                     granuleObj: obj
                 });
+                // remove object from addedFootprintStore
+                topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_FOOTPRINT, {
+                    granuleObj: obj
+                });
+                topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_FOOTPRINT, {
+                    granuleObj: this.addedFootprintStore[obj["Granule-Name"]]
+                });
+                delete this.addedFootprintStore[obj["Granule-Name"]];
             }
         },
 
@@ -998,10 +1016,20 @@ define([
                 topic.publish(GranuleSelectionEvent.prototype.ADD_GRANULE_PREVIEW, {
                     granuleObj: obj
                 });
+                // add to my separate store
+                this.addedPreviewStore[obj["Granule-Name"]] = obj;
             } else {
                 topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_PREVIEW, {
                     granuleObj: obj
                 });
+                // remove object from addedFootprintStore
+                topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_PREVIEW, {
+                    granuleObj: obj
+                });
+                topic.publish(GranuleSelectionEvent.prototype.REMOVE_GRANULE_PREVIEW, {
+                    granuleObj: this.addedPreviewStore[obj["Granule-Name"]]
+                });
+                delete this.addedPreviewStore[obj["Granule-Name"]];
             }
         },
 

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -392,20 +392,21 @@ define([
                     var granuleObjs = selectedGranules.map(function(x) {
                         var objectData = _context.granuleGrid.row(x).data
                         if(objectData.footprint) {
+                            granuleObjNames.push(objectData["Granule-Name"])
                             objectData.footprint = false
                             _context.gridStore.put(objectData)
                             _context.updateStateStoreObj(objectData);
                             _context.toggleFootprintDisplay(objectData);
                             return objectData;
                         } else {
-                            return
+                            return null
                         }
                     }).filter(function(x) {
                         x !== null
                     })
                     // deactivate granules from addedFootprints
                     Object.values(_context.addedFootprintStore).forEach(function(x) {
-                        if(!granuleObjNames.includes(x["Granule-Name"])) {
+                        if(granuleObjNames.includes(x["Granule-Name"])) {
                             granuleObjs.push(x);
                         }
                     })
@@ -463,11 +464,11 @@ define([
                     var granuleObjs = selectedGranules.map(function(x) {
                         var objectData = _context.granuleGrid.row(x).data
                         if(objectData.preview) {
+                            granuleObjNames.push(objectData["Granule-Name"]);
                             objectData.preview = false
                             _context.gridStore.put(objectData)
                             _context.updateStateStoreObj(objectData);
                             _context.togglePreviewDisplay(objectData);
-                            granuleObjNames.push(objectData["Granule-Name"]);
                             return objectData;
                         }else {
                             return null
@@ -477,7 +478,7 @@ define([
                     })
                     // deactivate granules from addedPreviews
                     Object.values(_context.addedPreviewStore).forEach(function(x) {
-                        if(!granuleObjNames.includes(x["Granule-Name"])) {
+                        if(granuleObjNames.includes(x["Granule-Name"])) {
                             granuleObjs.push(x);
                         }
                     })

--- a/src/jpl/dijit/GranulesController.js
+++ b/src/jpl/dijit/GranulesController.js
@@ -417,8 +417,9 @@ define([
                 label: "Clear all footprints",
                 iconClass: "fa fa-trash color-orange",
                 onClick: function(evt) {
-                    var stateStoreObjects = Array.from(_context.gridStore.query()).concat(Object.values(_context.addedFootprintStore))
-                    .map(function(obj){
+                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedFootprintStore)).filter(function(x) {
+                        return x.footprint
+                    }).map(function(obj){
                         obj.footprint = false
                         _context.gridStore.put(obj)
                         _context.updateStateStoreObj(obj);
@@ -489,9 +490,9 @@ define([
                 label: "Clear all image previews",
                 iconClass: "fa fa-trash color-orange",
                 onClick: function(evt) {
-                    // _context.hideAllPreviews();
-                    var stateStoreObjects = Array.from(_context.gridStore.query()).concat(Object.values(_context.addedPreviewStore))
-                    .map(function(obj){
+                    var stateStoreObjects = Array.from(_context.stateStore.query()).concat(Array.from(_context.gridStore.query())).concat(Object.values(_context.addedPreviewStore)).filter(function(x) {
+                        return x.preview
+                    }).map(function(obj){
                         obj.preview = false
                         _context.gridStore.put(obj)
                         _context.updateStateStoreObj(obj);

--- a/src/jpl/dijit/templates/HelpDialog.html
+++ b/src/jpl/dijit/templates/HelpDialog.html
@@ -127,10 +127,10 @@
                         <div class="help-container help-container-hidden" id="helpReleaseNotesContent">
                             <div>
                                 <div class="helpReleaseNotesVersionTitle">
-                                    <b>Version 4.17.2</b> (7/24/2024)
+                                    <b>Version 4.17.2</b> (8/28/2024)
                                 </div>
                                 <ul>
-                                    <li><span class="releaseNotesTag releaseNotesTagFixed">Fixed</span> Security and bug fixes.</li>
+                                    <li><span class="releaseNotesTag releaseNotesTagFixed">Fixed</span> Fixed granule selection's footprint and preview behavior.</li>
                                </ul>
                             </div>
                             <div>

--- a/src/jpl/dijit/templates/HelpDialog.html
+++ b/src/jpl/dijit/templates/HelpDialog.html
@@ -127,7 +127,7 @@
                         <div class="help-container help-container-hidden" id="helpReleaseNotesContent">
                             <div>
                                 <div class="helpReleaseNotesVersionTitle">
-                                    <b>Version 4.17.2</b> (8/28/2024)
+                                    <b>Version 4.17.2</b> (8/31/2024)
                                 </div>
                                 <ul>
                                     <li><span class="releaseNotesTag releaseNotesTagFixed">Fixed</span> Fixed granule selection's footprint and preview behavior.</li>


### PR DESCRIPTION
### Changes

- footprints and previews stay on map until deselected or the dataset gets removed.
- Stays on the map even if the granule is filtered out or not shown in the current list.