### PR TITLE
add launchpad token action to get tokens

### DIFF
--- a/.github/workflows/launchpad-token/action.yml
+++ b/.github/workflows/launchpad-token/action.yml
@@ -1,0 +1,47 @@
+name: "Get Launchpad Token"
+description: "Retrieves a Launchpad token using AWS Lambda"
+inputs:
+  aws-access-key-id:
+    required: true
+  aws-secret-access-key:
+    required: true
+  aws-region:
+    required: false
+    default: us-west-2
+  lambda-function:
+    required: true
+outputs:
+  result:
+    description: "The SM token retrieved from Lambda"
+    value: ${{ steps.get-token.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Invoke Launchpad Token Lambda
+      id: get-token
+      shell: bash
+      run: |
+        OUTPUT_FILE=result.json
+        PAYLOAD=$(echo '{"client_id": "l2sspyautotest", "minimum_alive_secs": 300}' | base64)
+
+        aws lambda invoke \
+          --function-name ${{ inputs.lambda-function }} \
+          --payload "$PAYLOAD" \
+          $OUTPUT_FILE > /dev/null 2>&1
+
+        if jq -e 'has("errorMessage")' "$OUTPUT_FILE" > /dev/null; then
+          echo "Error detected in Lambda response:"
+          cat "$OUTPUT_FILE"
+          exit 1
+        fi
+
+        RESULT=$(jq -r '.sm_token' < "$OUTPUT_FILE")
+        echo "::add-mask::$RESULT"
+        echo "result=$RESULT" >> $GITHUB_OUTPUT

--- a/.github/workflows/umm_t_sync.yml
+++ b/.github/workflows/umm_t_sync.yml
@@ -29,13 +29,31 @@ jobs:
       - name: Install CMR cmr_association_diff
         run: pip3 install git+https://github.com/podaac/cmr-association-diff.git@develop
 
+      - name: Get OPS token
+        id: ops_token
+        uses: ./.github/workflows/launchpad-token
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CUMULUS_OPS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CUMULUS_OPS }}
+          lambda-function: ops-launchpad_token_dispenser
+
+      - name: Get UAT token
+        id: uat_token
+        uses: ./.github/workflows/launchpad-token
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CUMULUS_UAT }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CUMULUS_UAT }}
+          lambda-function: uat-launchpad_token_dispenser
+
       - name: Run cmr_association_diff command
         id: cmr_association_diff
-
+        env:
+          UAT_TOKEN_TEMP: ${{ steps.ops_token.outputs.result }}
+          OPS_TOKEN_TEMP: ${{ steps.ops_token.outputs.result }}
         run: |
           update_git_message="Adding collections"
 
-          OPS_COLLECTION=$(set +x; cmr_association_diff -e ops -t tool -a ${{ github.workspace }}/cmr/ops_associations.txt -p POCLOUD -n 'HiTIDE' -o ${{ github.workspace }}/ops_output_json.txt --token ${{secrets.LAUNCHPAD_TOKEN_OPS}}; set -x)
+          OPS_COLLECTION=$(set +x; cmr_association_diff -e ops -t tool -a ${{ github.workspace }}/cmr/ops_associations.txt -p POCLOUD -n 'HiTIDE' -o ${{ github.workspace }}/ops_output_json.txt --token $UAT_TOKEN_TEMP; set -x)
           if [[ ${OPS_COLLECTION} ]]; then
             python -u ${{ github.workspace }}/.github/workflows/read_collection.py -e ops -i ${{ github.workspace }}/ops_output_json.txt -o ${{ github.workspace }}
             ops_success_collection=$(cat ${{ github.workspace }}/ops_success.txt | tr -d '\n')
@@ -43,7 +61,7 @@ jobs:
             cat ${{ github.workspace }}/ops_success.txt >> ${{ github.workspace }}/cmr/ops_associations.txt
           fi
 
-          UAT_COLLECTION=$(set +x; cmr_association_diff -e uat -t tool -a ${{ github.workspace }}/cmr/uat_associations.txt -p POCLOUD -n 'HiTIDE' -o ${{ github.workspace }}/uat_output_json.txt --token ${{secrets.LAUNCHPAD_TOKEN_UAT}}; set -x)
+          UAT_COLLECTION=$(set +x; cmr_association_diff -e uat -t tool -a ${{ github.workspace }}/cmr/uat_associations.txt -p POCLOUD -n 'HiTIDE' -o ${{ github.workspace }}/uat_output_json.txt --token $OPS_TOKEN_TEMP; set -x)
           if [[ ${UAT_COLLECTION} ]]; then
             python -u ${{ github.workspace }}/.github/workflows/read_collection.py -e uat -i ${{ github.workspace }}/uat_output_json.txt -o ${{ github.workspace }}
             uat_success_collection=$(cat ${{ github.workspace }}/uat_success.txt | tr -d '\n')


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Action for retrieving Launchpad tokens via AWS Lambda and integrates it into the `umm_t_sync` workflow. The workflow now dynamically fetches tokens for both OPS and UAT environments instead of relying on static secrets. The most important changes are:

**New GitHub Action for Token Retrieval:**
* Added `.github/workflows/launchpad-token/action.yml`, which defines a composite action to obtain a Launchpad token by invoking an AWS Lambda function. This action configures AWS credentials, calls the Lambda, processes the response, and outputs the token securely.

**Integration into Workflow:**
* Updated `.github/workflows/umm_t_sync.yml` to use the new `launchpad-token` action for both OPS and UAT environments, replacing the use of static secrets with dynamic token retrieval.

**Environment Variable Updates:**
* Modified the environment variables in the `Run cmr_association_diff command` step to use the dynamically retrieved tokens from the previous steps, increasing security and flexibility.

**Token Usage in Commands:**
* Updated the `cmr_association_diff` command invocations to use the new environment variables for tokens instead of referencing the old secrets directly.